### PR TITLE
docs: list the canonical maintainer commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@ code changes. Run the affected security or consumer gate when a change touches
 authentication, package exports, generated schemas, release evidence, or
 package boundaries.
 
+Use the canonical repository gates when the change needs them:
+
+```bash
+pnpm docs:build
+pnpm audit:all
+pnpm release:verify
+```
+
 Do not weaken a security check to make an unsupported configuration pass. Read
 `SECURITY.md` before you change authentication, OAuth, MCP, proxy, session,
 token, key, secret, or authorization behavior.


### PR DESCRIPTION
Future maintainers and agents need one direct command vocabulary across every Lupinum repository. This lists the existing documentation build, full audit, and release verification aliases in the repository agent guide without changing behavior.

Verification: git diff --check.

Risk: none. Documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized commands for building documentation, running complete audits, and verifying releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->