### PR TITLE
fix(ci): include deployable app audits in release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,9 @@ jobs:
           AUTH_CONTRACTS: ${{ needs.auth-contracts.result }}
           AUTH_REAL_BACKEND: ${{ needs.auth-real-backend.result }}
           COMPATIBILITY: ${{ needs.compatibility.result }}
+          DEPLOYABLE_APP_AUDITS: ${{ needs.deployable-app-audits.result }}
           SECRETS: ${{ needs.secrets.result }}
         run: |
-          for result in "$SECRETS" "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND"; do
+          for result in "$SECRETS" "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$DEPLOYABLE_APP_AUDITS"; do
             test "$result" = success
           done


### PR DESCRIPTION
The aggregate release gate claimed to require every independent source lane, but it did not inspect the documentation and demo audit result. Main protection now requires that audit directly, and this change also makes the aggregate gate fail when the deployable-app audit fails. Verified with Actionlint and whitespace validation.