### PR TITLE
chore(deps): enforce one quarantine policy

### DIFF
--- a/packages/mcp/pnpm-workspace.yaml
+++ b/packages/mcp/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-allowBuilds:
-  esbuild: true
-minimumReleaseAgeExclude:
-  - '@modelcontextprotocol/core@2.0.0'
-  - '@modelcontextprotocol/server@2.0.0'

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -3,8 +3,6 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
-const docsWorkspace = readFileSync(resolve(root, 'docs/pnpm-workspace.yaml'), 'utf8')
-const demoWorkspace = readFileSync(resolve(root, 'demo/pnpm-workspace.yaml'), 'utf8')
 const failures = []
 const check = (condition, message) => {
   if (!condition) failures.push(message)
@@ -16,14 +14,6 @@ check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(config.outputDirectory === null, 'Let Nuxt and Vercel detect .vercel/output.')
 check(config.buildCommand === 'pnpm build', 'Build the documentation app directly.')
 check(!('installCommand' in config), 'Let Vercel detect pnpm from the documentation lockfile.')
-check(
-  docsWorkspace.includes('minimumReleaseAge: 1440'),
-  'Quarantine fresh documentation dependencies for 24 hours.',
-)
-check(
-  demoWorkspace.includes('minimumReleaseAge: 1440'),
-  'Quarantine fresh demo dependencies for 24 hours.',
-)
 
 if (failures.length) {
   console.error(failures.join('\n'))

--- a/scripts/check-workspace-dependency-alignment.mjs
+++ b/scripts/check-workspace-dependency-alignment.mjs
@@ -28,6 +28,24 @@ const manifestPaths = [
 
 const failures = []
 
+for (const workspacePath of [
+  'pnpm-workspace.yaml',
+  'docs/pnpm-workspace.yaml',
+  'demo/pnpm-workspace.yaml',
+]) {
+  const workspace = readFileSync(resolve(rootDir, workspacePath), 'utf8')
+  if (!/^minimumReleaseAge:\s*1440\s*$/mu.test(workspace)) {
+    failures.push(`${workspacePath} must quarantine fresh dependencies for 24 hours`)
+  }
+  if (/^minimumReleaseAgeExclude:/mu.test(workspace)) {
+    failures.push(`${workspacePath} must not contain a committed dependency-age exception`)
+  }
+}
+
+if (existsSync(resolve(rootDir, 'packages/mcp/pnpm-workspace.yaml'))) {
+  failures.push('packages/mcp must use the root workspace policy and lockfile')
+}
+
 const workspacePackagesBlock =
   workspaceSource.match(/^packages:\s*(?:#.*)?\r?\n((?:[ \t].*(?:\r?\n|$))*)/mu)?.[1] ?? ''
 if (!/^\s+-\s+['"]?playground['"]?\s*(?:#.*)?$/mu.test(workspacePackagesBlock)) {


### PR DESCRIPTION
The MCP package had an unused nested workspace file with no lockfile. That file carried permanent dependency-age exceptions and could make future maintainers believe it owned an independent install boundary.

This change removes the redundant workspace file. The MCP package now uses the repository root policy and lockfile, like the release workflows already do. The workspace checker now owns the 24-hour quarantine contract for the three real install roots and rejects committed exceptions.

Verification:
- root frozen install
- MCP type-check and build
- full production audit for root, docs, and demo
- workspace policy check
- Vercel contract check
- formatting check