### PR TITLE
fix(release): verify first-package recovery

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -7,6 +7,11 @@ on:
         description: Exact Nuxt and Vue prerelease version
         required: true
         type: string
+      bootstrap_packages:
+        description: Comma-separated packages explicitly authorized for first-version bootstrap recovery
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: publish-better-convex
@@ -36,11 +41,13 @@ jobs:
           package-manager-cache: false
       - name: Require current main and the exact prerelease version
         env:
+          BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
           test "$GITHUB_REF" = refs/heads/main
           test "$(node -p "require('./package.json').version")" = "$RELEASE_VERSION"
           case "$RELEASE_VERSION" in *-*) ;; *) exit 1 ;; esac
+          node -e "const allowed=new Set(['@lupinum/better-convex-vue','@lupinum/better-convex-nuxt','@lupinum/better-convex-mcp']); const requested=(process.env.BOOTSTRAP_PACKAGES||'').split(',').map(value=>value.trim()).filter(Boolean); if(new Set(requested).size!==requested.length||requested.some(name=>!allowed.has(name))) throw new Error('bootstrap_packages must contain unique Better Convex package names.')"
       - name: Require an unused release tag
         env:
           GH_TOKEN: ${{ github.token }}
@@ -381,6 +388,9 @@ jobs:
     permissions:
       actions: read
       id-token: write
+    outputs:
+      mode: ${{ steps.publish.outputs.mode }}
+      package: ${{ steps.publish.outputs.package }}
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -392,6 +402,9 @@ jobs:
           name: release-candidate-vue-nuxt-set
           path: .release-artifacts
       - name: Publish the certified Vue tarball
+        id: publish
+        env:
+          BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
         run: |
           set -euo pipefail
           mapfile -t TARBALLS < <(find .release-artifacts -type f -name 'lupinum-better-convex-vue-*.tgz' -print)
@@ -401,16 +414,67 @@ jobs:
           PACKAGE=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.name)" "$RUNNER_TEMP/package.json")
           VERSION=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.version)" "$RUNNER_TEMP/package.json")
           LOCAL_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "$TARBALL" | openssl base64 -A)"
-          REGISTRY_ERROR="$RUNNER_TEMP/npm-view-vue-error"
-          if REGISTRY_INTEGRITY=$(npm view "$PACKAGE@$VERSION" dist.integrity 2>"$REGISTRY_ERROR"); then
-            test "$REGISTRY_INTEGRITY" = "$LOCAL_INTEGRITY"
-            echo "$PACKAGE@$VERSION already contains the certified bytes."
-          elif grep -q '\bE404\b' "$REGISTRY_ERROR"; then
-            npm publish "$TARBALL" --tag "$BCN_RELEASE_DIST_TAG" --access public --ignore-scripts --provenance
-          else
-            cat "$REGISTRY_ERROR" >&2
-            exit 1
-          fi
+          test "$PACKAGE" = '@lupinum/better-convex-vue'
+          export TARBALL PACKAGE VERSION LOCAL_INTEGRITY
+          node --input-type=module <<'NODE'
+          import { spawnSync } from 'node:child_process'
+          import { appendFileSync } from 'node:fs'
+          const fail = message => { throw new Error(message) }
+          const run = (args, inherit = false) => spawnSync('npm', args, {
+            encoding: 'utf8',
+            stdio: inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+          })
+          const view = (spec, field) => {
+            const result = run(['view', spec, field, '--json'])
+            if (result.status === 0) return JSON.parse(result.stdout.trim() || 'null')
+            if (/E404|404 Not Found/.test(result.stderr)) return null
+            fail(`npm view failed for ${spec} ${field}: ${result.stderr.trim()}`)
+          }
+          const { PACKAGE: packageName, VERSION: version, LOCAL_INTEGRITY: integrity } = process.env
+          const spec = `${packageName}@${version}`
+          const existing = view(spec, 'dist.integrity')
+          if (existing && existing !== integrity) fail(`${spec} exists with different bytes.`)
+          let mode
+          if (existing) {
+            const attestations = view(spec, 'dist.attestations')
+            const published = view(packageName, 'versions')
+            const versions = Array.isArray(published) ? published : [published]
+            if (!attestations && (versions.length !== 1 || versions[0] !== version)) {
+              fail(`${spec} is not the first package version and has no provenance.`)
+            }
+            const authorized = new Set((process.env.BOOTSTRAP_PACKAGES ?? '').split(',').map(value => value.trim()).filter(Boolean))
+            if (!attestations && !authorized.has(packageName)) {
+              fail(`${spec} requires explicit bootstrap authorization.`)
+            }
+            mode = attestations ? 'oidc' : 'bootstrap'
+          } else {
+            const result = run([
+              'publish', process.env.TARBALL, '--tag', process.env.BCN_RELEASE_DIST_TAG,
+              '--access', 'public', '--ignore-scripts', '--provenance',
+            ], true)
+            if (result.status !== 0) fail(`npm publish failed for ${spec}.`)
+            mode = 'oidc'
+          }
+          for (let attempt = 0; attempt < 12; attempt += 1) {
+            const registryIntegrity = view(spec, 'dist.integrity')
+            const attestations = view(spec, 'dist.attestations')
+            const channel = view(packageName, `dist-tags.${process.env.BCN_RELEASE_DIST_TAG}`)
+            const published = mode === 'bootstrap' ? view(packageName, 'versions') : null
+            const versions = Array.isArray(published) ? published : [published]
+            const remainsFirstVersion = mode !== 'bootstrap' || (versions.length === 1 && versions[0] === version)
+            if (
+              registryIntegrity === integrity && channel === version && remainsFirstVersion &&
+              (mode === 'bootstrap' || (mode === 'oidc' && attestations))
+            ) {
+              appendFileSync(process.env.GITHUB_OUTPUT, `mode=${mode}\n`)
+              appendFileSync(process.env.GITHUB_OUTPUT, `package=${packageName}\n`)
+              appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${packageName}: ${mode}.\n`)
+              process.exit(0)
+            }
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000)
+          }
+          fail(`${spec} did not expose the required bytes, provenance mode, and ${process.env.BCN_RELEASE_DIST_TAG}.`)
+          NODE
 
   registry-vue-nuxt-gate:
     needs: publish-vue
@@ -447,6 +511,9 @@ jobs:
     permissions:
       actions: read
       id-token: write
+    outputs:
+      mode: ${{ steps.publish.outputs.mode }}
+      package: ${{ steps.publish.outputs.package }}
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -458,6 +525,9 @@ jobs:
           name: release-candidate-vue-nuxt-set
           path: .release-artifacts
       - name: Publish the certified Nuxt tarball
+        id: publish
+        env:
+          BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
         run: |
           set -euo pipefail
           mapfile -t TARBALLS < <(find .release-artifacts -type f -name 'lupinum-better-convex-nuxt-*.tgz' -print)
@@ -467,16 +537,67 @@ jobs:
           PACKAGE=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.name)" "$RUNNER_TEMP/package.json")
           VERSION=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.version)" "$RUNNER_TEMP/package.json")
           LOCAL_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "$TARBALL" | openssl base64 -A)"
-          REGISTRY_ERROR="$RUNNER_TEMP/npm-view-nuxt-error"
-          if REGISTRY_INTEGRITY=$(npm view "$PACKAGE@$VERSION" dist.integrity 2>"$REGISTRY_ERROR"); then
-            test "$REGISTRY_INTEGRITY" = "$LOCAL_INTEGRITY"
-            echo "$PACKAGE@$VERSION already contains the certified bytes."
-          elif grep -q '\bE404\b' "$REGISTRY_ERROR"; then
-            npm publish "$TARBALL" --tag "$BCN_RELEASE_DIST_TAG" --access public --ignore-scripts --provenance
-          else
-            cat "$REGISTRY_ERROR" >&2
-            exit 1
-          fi
+          test "$PACKAGE" = '@lupinum/better-convex-nuxt'
+          export TARBALL PACKAGE VERSION LOCAL_INTEGRITY
+          node --input-type=module <<'NODE'
+          import { spawnSync } from 'node:child_process'
+          import { appendFileSync } from 'node:fs'
+          const fail = message => { throw new Error(message) }
+          const run = (args, inherit = false) => spawnSync('npm', args, {
+            encoding: 'utf8',
+            stdio: inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+          })
+          const view = (spec, field) => {
+            const result = run(['view', spec, field, '--json'])
+            if (result.status === 0) return JSON.parse(result.stdout.trim() || 'null')
+            if (/E404|404 Not Found/.test(result.stderr)) return null
+            fail(`npm view failed for ${spec} ${field}: ${result.stderr.trim()}`)
+          }
+          const { PACKAGE: packageName, VERSION: version, LOCAL_INTEGRITY: integrity } = process.env
+          const spec = `${packageName}@${version}`
+          const existing = view(spec, 'dist.integrity')
+          if (existing && existing !== integrity) fail(`${spec} exists with different bytes.`)
+          let mode
+          if (existing) {
+            const attestations = view(spec, 'dist.attestations')
+            const published = view(packageName, 'versions')
+            const versions = Array.isArray(published) ? published : [published]
+            if (!attestations && (versions.length !== 1 || versions[0] !== version)) {
+              fail(`${spec} is not the first package version and has no provenance.`)
+            }
+            const authorized = new Set((process.env.BOOTSTRAP_PACKAGES ?? '').split(',').map(value => value.trim()).filter(Boolean))
+            if (!attestations && !authorized.has(packageName)) {
+              fail(`${spec} requires explicit bootstrap authorization.`)
+            }
+            mode = attestations ? 'oidc' : 'bootstrap'
+          } else {
+            const result = run([
+              'publish', process.env.TARBALL, '--tag', process.env.BCN_RELEASE_DIST_TAG,
+              '--access', 'public', '--ignore-scripts', '--provenance',
+            ], true)
+            if (result.status !== 0) fail(`npm publish failed for ${spec}.`)
+            mode = 'oidc'
+          }
+          for (let attempt = 0; attempt < 12; attempt += 1) {
+            const registryIntegrity = view(spec, 'dist.integrity')
+            const attestations = view(spec, 'dist.attestations')
+            const channel = view(packageName, `dist-tags.${process.env.BCN_RELEASE_DIST_TAG}`)
+            const published = mode === 'bootstrap' ? view(packageName, 'versions') : null
+            const versions = Array.isArray(published) ? published : [published]
+            const remainsFirstVersion = mode !== 'bootstrap' || (versions.length === 1 && versions[0] === version)
+            if (
+              registryIntegrity === integrity && channel === version && remainsFirstVersion &&
+              (mode === 'bootstrap' || (mode === 'oidc' && attestations))
+            ) {
+              appendFileSync(process.env.GITHUB_OUTPUT, `mode=${mode}\n`)
+              appendFileSync(process.env.GITHUB_OUTPUT, `package=${packageName}\n`)
+              appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${packageName}: ${mode}.\n`)
+              process.exit(0)
+            }
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000)
+          }
+          fail(`${spec} did not expose the required bytes, provenance mode, and ${process.env.BCN_RELEASE_DIST_TAG}.`)
+          NODE
 
   registry-nuxt-gate:
     needs: publish-nuxt
@@ -511,6 +632,9 @@ jobs:
     permissions:
       actions: read
       id-token: write
+    outputs:
+      mode: ${{ steps.publish.outputs.mode }}
+      package: ${{ steps.publish.outputs.package }}
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -522,6 +646,9 @@ jobs:
           name: release-candidate-mcp
           path: .release-artifacts
       - name: Publish the certified MCP tarball
+        id: publish
+        env:
+          BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
         run: |
           set -euo pipefail
           mapfile -t TARBALLS < <(find .release-artifacts -type f -name 'lupinum-better-convex-mcp-*.tgz' -print)
@@ -531,16 +658,67 @@ jobs:
           PACKAGE=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.name)" "$RUNNER_TEMP/package.json")
           VERSION=$(node -e "const p = require(process.argv[1]); process.stdout.write(p.version)" "$RUNNER_TEMP/package.json")
           LOCAL_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "$TARBALL" | openssl base64 -A)"
-          REGISTRY_ERROR="$RUNNER_TEMP/npm-view-mcp-error"
-          if REGISTRY_INTEGRITY=$(npm view "$PACKAGE@$VERSION" dist.integrity 2>"$REGISTRY_ERROR"); then
-            test "$REGISTRY_INTEGRITY" = "$LOCAL_INTEGRITY"
-            echo "$PACKAGE@$VERSION already contains the certified bytes."
-          elif grep -q '\bE404\b' "$REGISTRY_ERROR"; then
-            npm publish "$TARBALL" --tag "$BCN_RELEASE_DIST_TAG" --access public --ignore-scripts --provenance
-          else
-            cat "$REGISTRY_ERROR" >&2
-            exit 1
-          fi
+          test "$PACKAGE" = '@lupinum/better-convex-mcp'
+          export TARBALL PACKAGE VERSION LOCAL_INTEGRITY
+          node --input-type=module <<'NODE'
+          import { spawnSync } from 'node:child_process'
+          import { appendFileSync } from 'node:fs'
+          const fail = message => { throw new Error(message) }
+          const run = (args, inherit = false) => spawnSync('npm', args, {
+            encoding: 'utf8',
+            stdio: inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+          })
+          const view = (spec, field) => {
+            const result = run(['view', spec, field, '--json'])
+            if (result.status === 0) return JSON.parse(result.stdout.trim() || 'null')
+            if (/E404|404 Not Found/.test(result.stderr)) return null
+            fail(`npm view failed for ${spec} ${field}: ${result.stderr.trim()}`)
+          }
+          const { PACKAGE: packageName, VERSION: version, LOCAL_INTEGRITY: integrity } = process.env
+          const spec = `${packageName}@${version}`
+          const existing = view(spec, 'dist.integrity')
+          if (existing && existing !== integrity) fail(`${spec} exists with different bytes.`)
+          let mode
+          if (existing) {
+            const attestations = view(spec, 'dist.attestations')
+            const published = view(packageName, 'versions')
+            const versions = Array.isArray(published) ? published : [published]
+            if (!attestations && (versions.length !== 1 || versions[0] !== version)) {
+              fail(`${spec} is not the first package version and has no provenance.`)
+            }
+            const authorized = new Set((process.env.BOOTSTRAP_PACKAGES ?? '').split(',').map(value => value.trim()).filter(Boolean))
+            if (!attestations && !authorized.has(packageName)) {
+              fail(`${spec} requires explicit bootstrap authorization.`)
+            }
+            mode = attestations ? 'oidc' : 'bootstrap'
+          } else {
+            const result = run([
+              'publish', process.env.TARBALL, '--tag', process.env.BCN_RELEASE_DIST_TAG,
+              '--access', 'public', '--ignore-scripts', '--provenance',
+            ], true)
+            if (result.status !== 0) fail(`npm publish failed for ${spec}.`)
+            mode = 'oidc'
+          }
+          for (let attempt = 0; attempt < 12; attempt += 1) {
+            const registryIntegrity = view(spec, 'dist.integrity')
+            const attestations = view(spec, 'dist.attestations')
+            const channel = view(packageName, `dist-tags.${process.env.BCN_RELEASE_DIST_TAG}`)
+            const published = mode === 'bootstrap' ? view(packageName, 'versions') : null
+            const versions = Array.isArray(published) ? published : [published]
+            const remainsFirstVersion = mode !== 'bootstrap' || (versions.length === 1 && versions[0] === version)
+            if (
+              registryIntegrity === integrity && channel === version && remainsFirstVersion &&
+              (mode === 'bootstrap' || (mode === 'oidc' && attestations))
+            ) {
+              appendFileSync(process.env.GITHUB_OUTPUT, `mode=${mode}\n`)
+              appendFileSync(process.env.GITHUB_OUTPUT, `package=${packageName}\n`)
+              appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${packageName}: ${mode}.\n`)
+              process.exit(0)
+            }
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000)
+          }
+          fail(`${spec} did not expose the required bytes, provenance mode, and ${process.env.BCN_RELEASE_DIST_TAG}.`)
+          NODE
 
   registry-mcp-gate:
     needs: publish-mcp
@@ -568,14 +746,33 @@ jobs:
         run: node scripts/compare-registry-package.mjs --package mcp
 
   published-package-set-complete:
-    needs: [registry-vue-nuxt-gate, registry-nuxt-gate, registry-mcp-gate]
+    needs:
+      - publish-vue
+      - registry-vue-nuxt-gate
+      - publish-nuxt
+      - registry-nuxt-gate
+      - publish-mcp
+      - registry-mcp-gate
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      vue-mode: ${{ needs.publish-vue.outputs.mode }}
+      nuxt-mode: ${{ needs.publish-nuxt.outputs.mode }}
+      mcp-mode: ${{ needs.publish-mcp.outputs.mode }}
+      vue-package: ${{ needs.publish-vue.outputs.package }}
+      nuxt-package: ${{ needs.publish-nuxt.outputs.package }}
+      mcp-package: ${{ needs.publish-mcp.outputs.package }}
     steps:
       - name: Record the verified package set
-        run: echo "All registry bytes and provenance match under ${BCN_RELEASE_DIST_TAG}."
+        env:
+          VUE_MODE: ${{ needs.publish-vue.outputs.mode }}
+          NUXT_MODE: ${{ needs.publish-nuxt.outputs.mode }}
+          MCP_MODE: ${{ needs.publish-mcp.outputs.mode }}
+        run: >-
+          echo "All registry bytes match under ${BCN_RELEASE_DIST_TAG}.
+          Publication modes: Vue=${VUE_MODE}, Nuxt=${NUXT_MODE}, MCP=${MCP_MODE}."
 
   github-prerelease:
     needs: published-package-set-complete
@@ -590,6 +787,12 @@ jobs:
       - name: Create or update the GitHub prerelease from the changelog
         env:
           GH_TOKEN: ${{ github.token }}
+          VUE_MODE: ${{ needs.published-package-set-complete.outputs.vue-mode }}
+          NUXT_MODE: ${{ needs.published-package-set-complete.outputs.nuxt-mode }}
+          MCP_MODE: ${{ needs.published-package-set-complete.outputs.mcp-mode }}
+          VUE_PACKAGE: ${{ needs.published-package-set-complete.outputs.vue-package }}
+          NUXT_PACKAGE: ${{ needs.published-package-set-complete.outputs.nuxt-package }}
+          MCP_PACKAGE: ${{ needs.published-package-set-complete.outputs.mcp-package }}
         run: |
           set -euo pipefail
           TAG="v${{ inputs.version }}"
@@ -602,4 +805,27 @@ jobs:
             capture { print }
           ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
           test -s "$RUNNER_TEMP/release-notes.md"
-          gh release create "$TAG" --target "$GITHUB_SHA" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+          bootstrap_packages=()
+          [ "$VUE_MODE" = bootstrap ] && bootstrap_packages+=("$VUE_PACKAGE")
+          [ "$NUXT_MODE" = bootstrap ] && bootstrap_packages+=("$NUXT_PACKAGE")
+          [ "$MCP_MODE" = bootstrap ] && bootstrap_packages+=("$MCP_PACKAGE")
+          if [ "${#bootstrap_packages[@]}" -gt 0 ]; then
+            cat >> "$RUNNER_TEMP/release-notes.md" <<'NOTICE'
+
+          > [!NOTE]
+          > This first npm version was created from the exact CI-certified artifact before npm trusted publishing could be configured. npm does not provide GitHub OIDC provenance for this bootstrap publication. The protected workflow verified the registry bytes. Later versions use trusted publishing with provenance.
+          NOTICE
+            bootstrap_list=$(IFS=,; echo "${bootstrap_packages[*]}")
+            printf '> Bootstrap packages: %s\n' "$bootstrap_list" >> "$RUNNER_TEMP/release-notes.md"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            read -r tag_type tag_sha < <(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '[.object.type, .object.sha] | @tsv')
+            while [ "$tag_type" = tag ]; do
+              read -r tag_type tag_sha < <(gh api "repos/$GITHUB_REPOSITORY/git/tags/$tag_sha" --jq '[.object.type, .object.sha] | @tsv')
+            done
+            test "$tag_type" = commit
+            test "$tag_sha" = "$GITHUB_SHA"
+            gh release edit "$TAG" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+          else
+            gh release create "$TAG" --target "$GITHUB_SHA" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -191,8 +191,14 @@ After immutable minting:
 The publish jobs are safe to rerun after an ambiguous registry response. Before
 publication, each job reads the package identity from its retained tarball and
 checks npm. If the version exists, the job continues only when its registry SRI
-equals the retained tarball SRI. If the version does not exist, the job
-publishes the same retained tarball. Never rebuild it.
+equals the retained tarball SRI. Missing provenance is accepted only when the
+version remains that package's sole published version and the dispatch names
+that package in `bootstrap_packages`. This explicit input authorizes only the
+known first-version recovery. Every other missing-provenance state stops the
+workflow. The workflow records each lane as `bootstrap` or `oidc` and names
+bootstrap packages in the GitHub prerelease. If the version does not exist, the
+job publishes the same retained tarball with OIDC and requires provenance.
+Never rebuild it.
 
 Never delete, replace, rebuild, repack, or publish a retired immutable
 coordinate. The internal decisions ledger and retained evidence directories

--- a/test/unit/release-bootstrap-policy.test.ts
+++ b/test/unit/release-bootstrap-policy.test.ts
@@ -1,0 +1,246 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/publish-prerelease.yml'),
+  'utf8',
+)
+const programs = extractPrograms(workflow).map((program) =>
+  dedent(program).replace(
+    'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000)',
+    'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 0)',
+  ),
+)
+const lanes = [
+  ['vue', '@lupinum/better-convex-vue'],
+  ['nuxt', '@lupinum/better-convex-nuxt'],
+  ['mcp', '@lupinum/better-convex-mcp'],
+] as const
+
+describe('first-package publication recovery', () => {
+  it('rejects every unsafe registry state', () => {
+    expect(programs).toHaveLength(lanes.length)
+    const [lane, packageName] = lanes[0]
+    const program = programs[0]
+    if (!program) throw new Error('Vue publish program is missing.')
+    runScenario(program, lane, packageName, 'missing package uses OIDC', {
+      expectedMode: 'oidc',
+      expectedPublishes: 1,
+    })
+    runScenario(program, lane, packageName, 'different bytes fail', {
+      existing: true,
+      differentBytes: true,
+      expectedError: 'exists with different bytes',
+    })
+    runScenario(program, lane, packageName, 'wrong dist-tag fails', {
+      existing: true,
+      attested: true,
+      wrongTag: true,
+      expectedError: 'did not expose the required bytes',
+    })
+    runScenario(program, lane, packageName, 'later unproven versions fail', {
+      existing: true,
+      extraVersion: true,
+      authorizeBootstrap: true,
+      expectedError: 'is not the first package version and has no provenance',
+    })
+    runScenario(program, lane, packageName, 'unauthorized bootstrap fails', {
+      existing: true,
+      expectedError: 'requires explicit bootstrap authorization',
+    })
+    runScenario(program, lane, packageName, 'bootstrap status is rechecked', {
+      existing: true,
+      laterVersionDuringVerification: true,
+      authorizeBootstrap: true,
+      expectedError: 'did not expose the required bytes',
+    })
+    runScenario(program, lane, packageName, 'fresh publication requires provenance', {
+      publishProvenance: false,
+      expectedError: 'did not expose the required bytes',
+    })
+    runScenario(program, lane, packageName, 'registry errors stop publication', {
+      registryError: true,
+      expectedError: 'npm view failed',
+    })
+  }, 30_000)
+
+  it('uses the same verified program and reports each lane independently', () => {
+    expect(new Set(programs).size).toBe(1)
+    for (const [index, [lane, packageName]] of lanes.entries()) {
+      const program = programs[index]
+      if (!program) throw new Error(`${lane} publish program is missing.`)
+      runScenario(program, lane, packageName, 'matching bootstrap bytes', {
+        existing: true,
+        authorizeBootstrap: true,
+        expectedMode: 'bootstrap',
+        expectedPublishes: 0,
+      })
+      runScenario(program, lane, packageName, 'attested rerun stays idempotent', {
+        existing: true,
+        attested: true,
+        extraVersion: true,
+        expectedMode: 'oidc',
+        expectedPublishes: 0,
+      })
+    }
+  }, 30_000)
+})
+
+function runScenario(
+  program: string,
+  lane: string,
+  packageName: string,
+  scenario: string,
+  options: {
+    authorizeBootstrap?: boolean
+    attested?: boolean
+    differentBytes?: boolean
+    existing?: boolean
+    expectedError?: string
+    expectedMode?: 'bootstrap' | 'oidc'
+    expectedPublishes?: number
+    extraVersion?: boolean
+    laterVersionDuringVerification?: boolean
+    publishProvenance?: boolean
+    registryError?: boolean
+    wrongTag?: boolean
+  },
+) {
+  const root = mkdtempSync(join(tmpdir(), `bcn-${lane}-publish-`))
+  try {
+    const bin = join(root, 'bin')
+    mkdirSync(bin)
+    const version = lane === 'mcp' ? '0.1.0-beta.28' : '0.8.0-beta.40'
+    const integrity = `sha512-${Buffer.alloc(64, lane).toString('base64')}`
+    const versions = [version]
+    if (options.extraVersion) versions.push(`${version}.1`)
+    const statePath = join(root, 'registry.json')
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        packageName,
+        version,
+        integrity,
+        existing: options.existing === true,
+        registryIntegrity: options.differentBytes ? 'sha512-different' : integrity,
+        attestations: options.attested ? { url: 'https://registry.example/provenance' } : null,
+        versions,
+        versionViews: 0,
+        addLaterVersion: options.laterVersionDuringVerification === true,
+        tag: options.wrongTag ? '0.0.0' : version,
+        publishProvenance: options.publishProvenance !== false,
+        registryError: options.registryError === true,
+        publishes: 0,
+      }),
+    )
+    const fakeNpm = join(bin, 'npm')
+    writeFileSync(fakeNpm, fakeNpmProgram())
+    chmodSync(fakeNpm, 0o755)
+    const runner = join(root, 'publish.mjs')
+    writeFileSync(runner, program)
+    const output = join(root, 'output.txt')
+    const result = spawnSync(process.execPath, [runner], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        BCN_RELEASE_DIST_TAG: 'next',
+        BOOTSTRAP_PACKAGES: options.authorizeBootstrap ? packageName : '',
+        FAKE_NPM_STATE: statePath,
+        GITHUB_OUTPUT: output,
+        GITHUB_STEP_SUMMARY: join(root, 'summary.md'),
+        LOCAL_INTEGRITY: integrity,
+        PACKAGE: packageName,
+        TARBALL: `${lane}.tgz`,
+        VERSION: version,
+      },
+    })
+    const diagnostic = `${result.stdout}\n${result.stderr}`
+    if (options.expectedError) {
+      expect(result.status, `${lane}: ${scenario} unexpectedly succeeded.`).not.toBe(0)
+      expect(diagnostic, `${lane}: ${scenario}`).toContain(options.expectedError)
+      return
+    }
+    expect(result.status, `${lane}: ${scenario}: ${diagnostic}`).toBe(0)
+    expect(readFileSync(output, 'utf8')).toContain(`mode=${options.expectedMode}`)
+    const state = JSON.parse(readFileSync(statePath, 'utf8')) as {
+      publishes: number
+    }
+    expect(state.publishes).toBe(options.expectedPublishes)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+}
+
+function dedent(value: string) {
+  const lines = value.split('\n')
+  const indentation = Math.min(
+    ...lines.filter(Boolean).map((line) => line.match(/^\s*/)?.[0].length ?? 0),
+  )
+  return lines.map((line) => line.slice(indentation)).join('\n')
+}
+
+function extractPrograms(source: string) {
+  const lines = source.split('\n')
+  const extracted: string[] = []
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index]?.includes("node --input-type=module <<'NODE'")) continue
+    const end = lines.findIndex((line, candidate) => candidate > index && line.trim() === 'NODE')
+    if (end === -1) throw new Error('Publish workflow has an unterminated inline Node program.')
+    extracted.push(lines.slice(index + 1, end).join('\n'))
+    index = end
+  }
+  return extracted
+}
+
+function fakeNpmProgram() {
+  return `#!/usr/bin/env node
+const fs = require('node:fs')
+const statePath = process.env.FAKE_NPM_STATE
+const state = JSON.parse(fs.readFileSync(statePath, 'utf8'))
+const args = process.argv.slice(2)
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state))
+const output = value => process.stdout.write(JSON.stringify(value) + '\\n')
+if (args[0] === 'view') {
+  if (state.registryError) {
+    process.stderr.write('E500 registry unavailable\\n')
+    process.exit(1)
+  }
+  const spec = args[1]
+  const field = args[2]
+  const versioned = spec.includes('@', 1) && spec.lastIndexOf('@') > spec.indexOf('/')
+  let value
+  if (!state.existing) value = undefined
+  else if (field === 'dist.integrity') value = state.registryIntegrity
+  else if (field === 'dist.attestations') value = state.attestations
+  else if (field === 'versions') {
+    if (state.addLaterVersion && state.versionViews > 0 && state.versions.length === 1) state.versions.push(state.version + '.1')
+    state.versionViews += 1
+    save()
+    value = state.versions
+  } else if (field.startsWith('dist-tags.')) value = state.tag
+  if (value === undefined || value === null || (!state.existing && versioned)) {
+    process.stderr.write('E404 404 Not Found\\n')
+    process.exit(1)
+  }
+  output(value)
+  process.exit(0)
+}
+if (args[0] === 'publish') {
+  state.existing = true
+  state.registryIntegrity = state.integrity
+  state.attestations = state.publishProvenance ? { url: 'https://registry.example/provenance' } : null
+  state.versions = [state.version]
+  state.tag = state.version
+  state.publishes += 1
+  save()
+  process.exit(0)
+}
+throw new Error('Unsupported fake npm command: ' + args.join(' '))
+`
+}

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -343,8 +343,11 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       'publish-mcp': ['registry-nuxt-gate'],
       'registry-mcp-gate': ['publish-mcp'],
       'published-package-set-complete': [
+        'publish-vue',
         'registry-vue-nuxt-gate',
+        'publish-nuxt',
         'registry-nuxt-gate',
+        'publish-mcp',
         'registry-mcp-gate',
       ],
       'github-prerelease': ['published-package-set-complete'],
@@ -532,6 +535,13 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     expect(workflow.on).toEqual({
       workflow_dispatch: {
         inputs: {
+          bootstrap_packages: {
+            description:
+              'Comma-separated packages explicitly authorized for first-version bootstrap recovery',
+            required: false,
+            default: '',
+            type: 'string',
+          },
           version: {
             description: 'Exact Nuxt and Vue prerelease version',
             required: true,
@@ -554,15 +564,14 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     const publishRuns = oidcJobs.flatMap(({ job }) =>
       (job.steps ?? [])
         .map(normalizedRun)
-        .filter((run): run is string => run?.includes('npm publish ') ?? false),
+        .filter((run): run is string => run?.includes("'publish', process.env.TARBALL") ?? false),
     )
     expect(publishRuns).toHaveLength(3)
     expect(
       publishRuns.every(
         (run) =>
-          run.includes('--tag "$BCN_RELEASE_DIST_TAG"') &&
-          run.includes('--ignore-scripts') &&
-          run.includes('--provenance'),
+          run.includes('process.env.BCN_RELEASE_DIST_TAG') &&
+          run.includes("'--ignore-scripts', '--provenance'"),
       ),
     ).toBe(true)
     for (const { job } of oidcJobs) {
@@ -574,14 +583,18 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       )
       expect((job.steps ?? []).map(normalizedRun).join('\n')).toContain('LOCAL_INTEGRITY="sha512-')
       expect((job.steps ?? []).map(normalizedRun).join('\n')).toContain(
-        'npm view "$PACKAGE@$VERSION" dist.integrity',
+        "view(spec, 'dist.integrity')",
       )
-      expect((job.steps ?? []).map(normalizedRun).join('\n')).toContain("grep -q '\\bE404\\b'")
+      expect((job.steps ?? []).map(normalizedRun).join('\n')).toContain(
+        "view(spec, 'dist.attestations')",
+      )
+      expect((job.steps ?? []).map(normalizedRun).join('\n')).toContain('versions.length !== 1')
       const rawPublishRun = (job.steps ?? []).find(
-        (step) => typeof step.run === 'string' && step.run.includes('npm publish '),
+        (step) =>
+          typeof step.run === 'string' && step.run.includes("'publish', process.env.TARBALL"),
       )?.run
       expect(rawPublishRun).toBeTypeOf('string')
-      expect(rawPublishRun).toMatch(/cat "\$REGISTRY_ERROR" >&2(?:\r?\n|;)\s*exit 1\b/u)
+      expect(rawPublishRun).toContain('npm view failed for')
       expect(job.permissions).toEqual({ actions: 'read', 'id-token': 'write' })
     }
 
@@ -596,57 +609,13 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     const githubReleaseRuns = runs(workflow, 'github-prerelease').join('\n')
     expect(githubReleaseRuns).toContain('gh release create')
     expect(githubReleaseRuns).toContain('--target "$GITHUB_SHA"')
-    expect(githubReleaseRuns).not.toContain('gh release edit')
-    expect(githubReleaseRuns).not.toMatch(/pnpm|npm install|node scripts\//u)
-  })
-
-  it('does not publish from any OIDC workflow branch after a non-404 registry error', () => {
-    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'bcn-workflow-registry-error-'))
-    const fakeBin = join(temporaryDirectory, 'bin')
-    const fakeNpm = join(fakeBin, 'npm')
-    const executionLog = join(temporaryDirectory, 'executed.log')
-    mkdirSync(fakeBin)
-    writeFileSync(
-      fakeNpm,
-      `#!/bin/sh
-if [ "$1" = "view" ]; then
-  printf '{"error":{"code":"E500"}}\\n' >&2
-  exit 1
-fi
-printf '%s\\n' "$*" >> "$BCN_FAKE_NPM_LOG"
-`,
+    expect(githubReleaseRuns).toContain('gh release edit')
+    expect(githubReleaseRuns).toContain('git/ref/tags/$TAG')
+    expect(githubReleaseRuns).toContain('test "$tag_sha" = "$GITHUB_SHA"')
+    expect(githubReleaseRuns).toContain(
+      'This first npm version was created from the exact CI-certified artifact',
     )
-    chmodSync(fakeNpm, 0o755)
-
-    try {
-      for (const jobId of ['publish-vue', 'publish-nuxt', 'publish-mcp']) {
-        const rawRun = steps(workflow, jobId).find(
-          (step) => typeof step.run === 'string' && step.run.includes('npm publish '),
-        )?.run
-        if (typeof rawRun !== 'string') throw new Error(`Missing publish run for ${jobId}`)
-        const guardedBranch = rawRun.slice(rawRun.indexOf('REGISTRY_ERROR='))
-        const result = spawnSync('/bin/sh', ['-c', guardedBranch], {
-          cwd: temporaryDirectory,
-          encoding: 'utf8',
-          env: {
-            ...process.env,
-            BCN_RELEASE_DIST_TAG: 'next',
-            BCN_FAKE_NPM_LOG: executionLog,
-            LOCAL_INTEGRITY: 'sha512-local',
-            PACKAGE: 'example-package',
-            PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
-            RUNNER_TEMP: temporaryDirectory,
-            TARBALL: 'example.tgz',
-            VERSION: '1.0.0',
-          },
-        })
-        expect(result.status, `${jobId}: ${result.stderr}`).toBe(1)
-        expect(result.stderr).toContain('E500')
-        expect(existsSync(executionLog)).toBe(false)
-      }
-    } finally {
-      rmSync(temporaryDirectory, { force: true, recursive: true })
-    }
+    expect(githubReleaseRuns).not.toMatch(/pnpm|npm install|node scripts\//u)
   })
 
   it('makes exact-host cloud staging block publication', () => {


### PR DESCRIPTION
npm cannot configure trusted publishing before the three scoped packages exist. The current release workflow can recognize matching bytes, but it does not distinguish the one-time bootstrap exception from a normal OIDC publication.

This change keeps the existing three protected lanes and makes each report `bootstrap` or `oidc`. Existing bytes must match the retained tarball and may omit provenance only while they remain the sole package version. New workflow publications must expose provenance and `next`. The GitHub prerelease records the exact bootstrap packages instead of claiming provenance for every lane.

Verification:
- `actionlint .github/workflows/publish-prerelease.yml`
- focused release workflow tests: 19 passed
- formatting, lint, type checks, and architecture boundaries passed
- the unrelated socket-heavy local suite was stopped after macOS Codex sandbox timeouts; required GitHub checks remain authoritative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved prerelease publishing verification for package integrity, versions, distribution tags, and provenance.
  * New package publications use OIDC authentication and provenance attestation.
  * Existing packages can safely support approved bootstrap or OIDC publishing modes.
  * GitHub prerelease notes now identify bootstrap-published packages and their provenance status.

* **Bug Fixes**
  * Release reruns now verify retained package archives before accepting existing versions.
  * Added safeguards for version races and registry failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->