### PR TITLE
docs(release): document first-package bootstrap

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,17 @@
 # Releasing Better Convex
 
-Public packages are published only by
+Normal package versions are published only by
 `.github/workflows/publish-prerelease.yml` through npm trusted publishing. A
-workstation may run disposable checks, but it must never publish, promote, or
-create authoritative release evidence.
+workstation may run disposable checks, but it must not publish, promote, tag,
+or create authoritative release evidence.
+
+npm cannot configure trusted publishing before a package exists. The first
+version of each new package therefore has one narrow exception: after the
+protected workflow certifies and retains the exact tarball, the owning human
+may publish that file once with two-factor authentication. Do not rebuild or
+repack it. The protected workflow must then verify the registry bytes and
+create the Git tag and GitHub prerelease. Later versions have no workstation
+publication path.
 
 ## The one release path
 
@@ -17,7 +25,8 @@ The order is fixed:
 5. Verify only those artifact bytes and clean consumers.
 6. Deploy the exact Nuxt artifact to the dedicated Vercel staging host.
 7. Run the protected Convex/Vercel proof and prove complete cleanup.
-8. Publish through npm trusted publishing under `next`.
+8. Publish through npm trusted publishing under `next`, or complete the
+   first-package bootstrap described below.
 9. Download each package from npm and compare it with the certified SRI.
 10. Create the Git tag and GitHub prerelease from the matching changelog entry.
 
@@ -178,6 +187,31 @@ it with the certified artifact. The Vue gate also installs the unchanged Nuxt
 artifact with the registry Vue package in a clean consumer. Prerelease
 publication uses `next`. A stable workflow may use `latest` only after a
 separate stable-release review.
+
+## First-package bootstrap
+
+Use this section only while an `@lupinum/better-convex-*` package does not yet
+exist and npm therefore rejects its trusted-publisher configuration.
+
+1. Dispatch the protected workflow with all missing packages listed in
+   `bootstrap_packages`.
+2. Approve and complete the protected staging proof. Do not approve the `npm`
+   environment yet.
+3. Download the three retained tarballs and their evidence from that exact
+   workflow run.
+4. Verify each tarball against its retained SHA-256 and SRI. Do not run
+   `npm pack` or rebuild any package.
+5. Sign in to npm with the owning human account and two-factor authentication.
+6. Publish each exact file with `--access public --tag next --ignore-scripts`.
+7. Configure each package's trusted publisher for
+   `publish-prerelease.yml` and the protected `npm` environment.
+8. Approve the waiting `npm` environment.
+
+The workflow must detect the existing versions, require registry SRI equality,
+verify `next`, record each lane as `bootstrap`, and create the Git tag and
+GitHub prerelease from the certified source commit. The first versions do not
+have GitHub OIDC provenance. This is a recorded npm bootstrap limitation, not
+permission to publish another version from a workstation.
 
 ## Failure, retry, and version rules
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -201,8 +201,13 @@ exist and npm therefore rejects its trusted-publisher configuration.
    workflow run.
 4. Verify each tarball against its retained SHA-256 and SRI. Do not run
    `npm pack` or rebuild any package.
-5. Sign in to npm with the owning human account and two-factor authentication.
-6. Publish each exact file with `--access public --tag next --ignore-scripts`.
+5. Confirm that the owning npm account requires two-factor authentication for
+   authorization and writes. Do not use an access token that bypasses two-factor
+   authentication.
+6. Sign in to npm with that account. Publish each exact file with
+   `--access public --tag next --ignore-scripts`. Let npm request the one-time
+   password interactively for every publication. Do not put a one-time password
+   in a command, shell history, script, or log.
 7. Configure each package's trusted publisher for
    `publish-prerelease.yml` and the protected `npm` environment.
 8. Approve the waiting `npm` environment.

--- a/test/unit/package-manifest-consistency.test.ts
+++ b/test/unit/package-manifest-consistency.test.ts
@@ -162,6 +162,12 @@ describe('contributor intake consistency', () => {
     ]) {
       expect(maintaining).toContain(`## ${heading}`)
     }
+
+    const releasing = readFileSync(resolve(repositoryRoot, 'RELEASING.md'), 'utf8')
+    expect(releasing).toContain('## First-package bootstrap')
+    expect(releasing).toContain('npm cannot configure trusted publishing before a package exists')
+    expect(releasing).toContain('--access public --tag next --ignore-scripts')
+    expect(releasing).toMatch(/Later versions have no workstation\s+publication path\./u)
   })
 })
 

--- a/test/unit/package-manifest-consistency.test.ts
+++ b/test/unit/package-manifest-consistency.test.ts
@@ -164,9 +164,24 @@ describe('contributor intake consistency', () => {
     }
 
     const releasing = readFileSync(resolve(repositoryRoot, 'RELEASING.md'), 'utf8')
-    expect(releasing).toContain('## First-package bootstrap')
-    expect(releasing).toContain('npm cannot configure trusted publishing before a package exists')
-    expect(releasing).toContain('--access public --tag next --ignore-scripts')
+    const bootstrapHeading = '## First-package bootstrap'
+    const bootstrapStart = releasing.indexOf(bootstrapHeading)
+    const bootstrapEnd = releasing.indexOf('\n## ', bootstrapStart + bootstrapHeading.length)
+    expect(bootstrapStart).toBeGreaterThanOrEqual(0)
+    expect(bootstrapEnd).toBeGreaterThan(bootstrapStart)
+
+    const bootstrap = releasing.slice(bootstrapStart, bootstrapEnd)
+    const afterBootstrap = releasing.slice(bootstrapEnd)
+    expect(bootstrap).toContain('npm therefore rejects its trusted-publisher configuration')
+    expect(bootstrap).toContain('--access public --tag next --ignore-scripts')
+    expect(bootstrap).toContain('two-factor authentication for')
+    expect(bootstrap).toContain('authorization and writes')
+    expect(bootstrap).toContain('Do not use an access token that bypasses two-factor')
+    expect(bootstrap).toContain('Let npm request the one-time')
+    expect(afterBootstrap).not.toMatch(
+      /(?:workstation|owning human).{0,120}(?:publish|tag|release)/su,
+    )
+    expect(afterBootstrap).not.toContain('--access public --tag next --ignore-scripts')
     expect(releasing).toMatch(/Later versions have no workstation\s+publication path\./u)
   })
 })


### PR DESCRIPTION
Better Convex prohibited every workstation publication, but npm cannot create a trusted-publisher record before a new package exists. That contradicted the shared Lupinum first-release procedure and left the three scoped packages without a documented bootstrap path.

This change documents one narrow exception for the owning human: publish only the exact retained tarballs after the protected staging proof, configure trusted publishing, and let the protected workflow verify registry equality and create the public release. Every later version remains workflow-only. A repository test keeps these boundaries in the runbook.

Verification:

- `pnpm check` — 174 files and 2,056 tests passed
- `pnpm docs:build` — 342 routes prerendered
- focused policy test — 18 tests passed
- `git diff --check`

Risk: Low. This changes release documentation and its policy test only. It does not change package bytes, publication code, or public APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance with a narrowly scoped, MFA-protected option for bootstrapping the first package when trusted publishing is unavailable.
  * Clarified artifact verification, one-time publication, trusted publishing setup, tagging, and prerelease verification requirements.

* **Tests**
  * Expanded consistency checks to validate the new bootstrap guidance and prevent unsupported workstation-based publication steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->