### PR TITLE
fix(release): accept prepared changelog section

### DIFF
--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,21 @@
+export function requirePreparedReleaseNotes(changelog, tag) {
+  const heading = `## ${tag}`
+  const lines = changelog.split(/\r?\n/u)
+  const matches = lines.flatMap((line, index) => (line === heading ? [index] : []))
+
+  if (matches.length !== 1) {
+    throw new Error(`CHANGELOG.md must contain exactly one ${heading} release section.`)
+  }
+
+  const start = matches[0] + 1
+  const nextHeading = lines.findIndex((line, index) => index >= start && line.startsWith('## '))
+  const notes = lines
+    .slice(start, nextHeading === -1 ? undefined : nextHeading)
+    .join('\n')
+    .trim()
+  if (!/^- /mu.test(notes)) {
+    throw new Error(`CHANGELOG.md ${heading} release section must contain non-empty notes.`)
+  }
+
+  return notes
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,6 +38,7 @@ import {
 } from './package-check/production-manifest-contract.mjs'
 import { buildContentManifest, packAndExtract } from './package-check/tarball.mjs'
 import { assertPackedRuntimeFingerprintBinding } from './package-runtime-fingerprint-profile.mjs'
+import { requirePreparedReleaseNotes } from './release-changelog.mjs'
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const { command, packageId: releasePackageId, verifyPath } = parseArguments(process.argv.slice(2))
@@ -118,18 +119,7 @@ function ensureCleanWorkingTree() {
 
 function requirePreparedChangelog() {
   const changelog = readFileSync(join(repoRoot, 'CHANGELOG.md'), 'utf8')
-  const unreleased = changelog
-    .split(/^## Unreleased\s*$/mu)[1]
-    ?.split(/^## /mu)[0]
-    ?.trim()
-  if (!unreleased || !/^- /mu.test(unreleased)) {
-    throw new Error('CHANGELOG.md must contain non-empty Unreleased notes before minting.')
-  }
-  if (changelog.includes(`## ${tag}`)) {
-    throw new Error(
-      `CHANGELOG.md must not present unpublished ${tag} as published before registry equality.`,
-    )
-  }
+  requirePreparedReleaseNotes(changelog, tag)
 }
 
 function assertReleaseTagIsUnusedOrCurrent(currentCommit) {

--- a/test/unit/release-changelog.test.ts
+++ b/test/unit/release-changelog.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { requirePreparedReleaseNotes } from '../../scripts/release-changelog.mjs'
+
+describe('prepared release changelog', () => {
+  const tag = 'v0.8.0-beta.40'
+
+  it('returns the exact prepared release section', () => {
+    expect(
+      requirePreparedReleaseNotes(
+        `# Changelog\n\n## ${tag}\n\n- Ship the certified package set.\n\n## v0.7.0\n\n- Older release.\n`,
+        tag,
+      ),
+    ).toBe('- Ship the certified package set.')
+  })
+
+  it.each([
+    ['an Unreleased section only', '# Changelog\n\n## Unreleased\n\n- Draft notes.\n'],
+    ['an empty exact section', `# Changelog\n\n## ${tag}\n\n## v0.7.0\n\n- Older.\n`],
+    ['a prefixed version', `# Changelog\n\n## preview-${tag}\n\n- Wrong release.\n`],
+    ['a suffixed version', `# Changelog\n\n## ${tag}-extra\n\n- Wrong release.\n`],
+    [
+      'duplicate exact sections',
+      `# Changelog\n\n## ${tag}\n\n- First.\n\n## ${tag}\n\n- Second.\n`,
+    ],
+  ])('rejects %s', (_label, changelog) => {
+    expect(() => requirePreparedReleaseNotes(changelog, tag)).toThrow(/CHANGELOG\.md/u)
+  })
+})


### PR DESCRIPTION
## Result

The protected release built the package set and then rejected the prepared v0.8.0-beta.40 changelog entry because the artifact builder still expected a separate Unreleased section. The artifact builder now requires the exact version section that the GitHub release consumes. This removes the contradictory second changelog state without weakening the release gate.

## Verification

- pnpm check: 174 test files and 2,049 tests passed
- Focused changelog and release-workflow tests: 21 tests passed
- ESLint, formatting, and git diff checks passed
- [ ] I ran pnpm verify, or I explained why it does not apply. The canonical pnpm check handoff gate passed. The remaining verify work duplicates broad audits and documentation builds that the required hosted checks run and that this release-only change does not affect.

## Documentation and compatibility

- [x] Public documentation does not change because the documented release path already requires the exact version section.
- [x] I added tests for the changed invariant or failure boundary.
- [x] Package versions, public APIs, and compatibility do not change.
- [x] I kept application authorization in Convex.
- [x] I kept server-only code outside browser bundles.
- [x] I kept this pull request focused on one concern.
- [x] I did not include credentials, tokens, private data, or generated artifacts.

## Release note

None. This repairs release automation for the already prepared version and does not change package behavior.

## Risk

The main risk is accepting the wrong changelog section. Exact-heading, missing, empty, prefixed, suffixed, and duplicate-section tests keep this fail-closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release preparation now validates that exactly one matching release section exists.
  * Releases with missing, duplicate, empty, or incorrectly formatted notes are rejected with clearer errors.
* **Chores**
  * Release processing now consistently uses the prepared release notes validation.
* **Tests**
  * Added coverage for valid release sections and common changelog formatting errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->