### PR TITLE
fix(release): use one family changelog tag

### DIFF
--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,3 +1,13 @@
+import { validatePackageArtifactVersion } from './package-artifact-coordinates.mjs'
+
+export function getReleaseFamilyTag(workspaceVersion) {
+  try {
+    return `v${validatePackageArtifactVersion(workspaceVersion)}`
+  } catch {
+    throw new Error('Workspace package.json must declare a canonical release-family version.')
+  }
+}
+
 export function requirePreparedReleaseNotes(changelog, tag) {
   const heading = `## ${tag}`
   const lines = changelog.split(/\r?\n/u)

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -39,7 +39,13 @@ withReleasePreflightTarballs((tarballs) => {
   run('node', ['scripts/check-package-exports.mjs', '--package', 'mcp', '--tarball', tarballs.mcp])
 })
 
-run('pnpm', ['exec', 'vitest', 'run', 'test/unit/release-workflow.test.ts'])
+run('pnpm', [
+  'exec',
+  'vitest',
+  'run',
+  'test/unit/release-changelog.test.ts',
+  'test/unit/release-workflow.test.ts',
+])
 ensureClean()
 console.log(
   '\n[release-smoke] PASS: locks, release-equivalent packages, consumers, and regressions.',

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,7 +38,7 @@ import {
 } from './package-check/production-manifest-contract.mjs'
 import { buildContentManifest, packAndExtract } from './package-check/tarball.mjs'
 import { assertPackedRuntimeFingerprintBinding } from './package-runtime-fingerprint-profile.mjs'
-import { requirePreparedReleaseNotes } from './release-changelog.mjs'
+import { getReleaseFamilyTag, requirePreparedReleaseNotes } from './release-changelog.mjs'
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const { command, packageId: releasePackageId, verifyPath } = parseArguments(process.argv.slice(2))
@@ -56,7 +56,7 @@ if (
   throw new Error('Workspace package.json must declare the release package manager.')
 }
 const version = artifactCoordinates.version
-const tag = `v${version}`
+const tag = getReleaseFamilyTag(workspacePackageJson.version)
 const expectedArtifactFiles = artifactCoordinates.files
 
 function parseArguments(args) {

--- a/test/unit/release-changelog.test.ts
+++ b/test/unit/release-changelog.test.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
-import { requirePreparedReleaseNotes } from '../../scripts/release-changelog.mjs'
+import {
+  getReleaseFamilyTag,
+  requirePreparedReleaseNotes,
+} from '../../scripts/release-changelog.mjs'
 
 describe('prepared release changelog', () => {
   const tag = 'v0.8.0-beta.40'
@@ -12,6 +18,35 @@ describe('prepared release changelog', () => {
         tag,
       ),
     ).toBe('- Ship the certified package set.')
+  })
+
+  it('uses one root release tag for packages with different npm versions', () => {
+    const workspace = JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as {
+      version: string
+    }
+    const mcp = JSON.parse(readFileSync(resolve('packages/mcp/package.json'), 'utf8')) as {
+      version: string
+    }
+    const changelog = readFileSync(resolve('CHANGELOG.md'), 'utf8')
+
+    expect(mcp.version).not.toBe(workspace.version)
+    expect(getReleaseFamilyTag(workspace.version)).toBe(tag)
+    expect(requirePreparedReleaseNotes(changelog, tag)).toContain('@lupinum/better-convex-mcp')
+  })
+
+  it.each([
+    null,
+    undefined,
+    '',
+    ' 0.8.0',
+    '0.8',
+    'v0.8.0',
+    '0.8.0 beta.40',
+    '01.2.3',
+    '1.2.3-01',
+    '1.2.3-alpha..1',
+  ])('rejects malformed release-family version %j', (version) => {
+    expect(() => getReleaseFamilyTag(version)).toThrow(/release-family version/u)
   })
 
   it.each([


### PR DESCRIPTION
## Result

The protected release built and uploaded the Vue and Nuxt candidates, then rejected MCP because it looked for the MCP npm version as a GitHub release heading. Better Convex has three package versions but one release family. All package artifact lanes now use the root workspace version for the changelog and GitHub tag while retaining their own npm versions.

The required release smoke now runs the release-family changelog regression test, so this exact mismatch blocks pull requests before another dispatch.

## Verification

- pnpm check: 174 test files and 2,055 tests passed
- Focused release-family and workflow suite: 27 tests passed
- The test proves root 0.8.0-beta.40 and MCP 0.1.0-beta.28 both use v0.8.0-beta.40
- ESLint, formatting, and git diff checks passed
- Local release smoke built all three packages and reached the documented macOS versus Linux archive-integrity boundary. The required Linux release-smoke check is authoritative for the reviewed candidate locks.
- [ ] I ran pnpm verify, or I explained why it does not apply. The canonical pnpm check gate passed. Hosted PR checks run the remaining audits, docs, consumers, and Linux release smoke.

## Documentation and compatibility

- [x] Public release documentation already defines one release-family tag.
- [x] I added tests for the changed invariant and failure boundary.
- [x] Package versions, public APIs, and compatibility do not change.
- [x] I kept application authorization in Convex.
- [x] I kept server-only code outside browser bundles.
- [x] I kept this pull request focused on one concern.
- [x] I did not include credentials, tokens, private data, or generated artifacts.

## Release note

None. This repairs automation for the already prepared package set.

## Risk

The main risk is mixing package versions with the shared release tag. The release gate now reads the tag from the root workspace manifest and tests the real divergent MCP version and current changelog together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release tags now consistently derive from the workspace version, ensuring packages with different versions share the correct release tag.
  * Invalid or malformed workspace versions now produce clear validation errors.

* **Tests**
  * Expanded release validation coverage, including mismatched package versions and invalid version formats.
  * Release smoke checks now cover both changelog and workflow validation suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->