### PR TITLE
fix(release): install browser before candidate verification

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -190,6 +190,10 @@ jobs:
         run: npm install --global npm@"$RELEASE_NPM_VERSION" corepack@0.34.5 && corepack enable
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Install the packed-consumer browser
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Resolve the reviewed candidate coordinates
         id: candidate_set
         run: node scripts/print-candidate-set-coordinates.mjs >> "$GITHUB_OUTPUT"

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -385,13 +385,20 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       '${{ steps.candidate_set.outputs.artifact_name }}',
       '${{ steps.mcp.outputs.artifact_name }}',
     ])
-    expect(runs(workflow, 'verify-candidates')).toEqual(
+    const verifyRuns = runs(workflow, 'verify-candidates')
+    expect(verifyRuns).toEqual(
       expect.arrayContaining([
+        'pnpm exec playwright install --with-deps chromium',
         'pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"',
         'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
         'pnpm release:verify --package nuxt --artifact-manifest "${{ steps.nuxt.outputs.evidence }}"',
         'pnpm release:verify --package mcp --artifact-manifest "${{ steps.mcp.outputs.evidence }}"',
       ]),
+    )
+    expect(verifyRuns.indexOf('pnpm exec playwright install --with-deps chromium')).toBeLessThan(
+      verifyRuns.indexOf(
+        'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
+      ),
     )
   })
 

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -395,7 +395,9 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     ]
     const verificationIndexes = orderedVerificationRuns.map((run) => verifyRuns.indexOf(run))
     expect(verificationIndexes.every((index) => index >= 0)).toBe(true)
-    expect(verificationIndexes).toEqual([...verificationIndexes].sort((left, right) => left - right))
+    expect(verificationIndexes).toEqual(
+      [...verificationIndexes].sort((left, right) => left - right),
+    )
   })
 
   it('retries post-mint work against transferred bytes without rebuilding', () => {

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -386,20 +386,16 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       '${{ steps.mcp.outputs.artifact_name }}',
     ])
     const verifyRuns = runs(workflow, 'verify-candidates')
-    expect(verifyRuns).toEqual(
-      expect.arrayContaining([
-        'pnpm exec playwright install --with-deps chromium',
-        'pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"',
-        'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
-        'pnpm release:verify --package nuxt --artifact-manifest "${{ steps.nuxt.outputs.evidence }}"',
-        'pnpm release:verify --package mcp --artifact-manifest "${{ steps.mcp.outputs.evidence }}"',
-      ]),
-    )
-    expect(verifyRuns.indexOf('pnpm exec playwright install --with-deps chromium')).toBeLessThan(
-      verifyRuns.indexOf(
-        'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
-      ),
-    )
+    const orderedVerificationRuns = [
+      'pnpm exec playwright install --with-deps chromium',
+      'pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"',
+      'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
+      'pnpm release:verify --package nuxt --artifact-manifest "${{ steps.nuxt.outputs.evidence }}"',
+      'pnpm release:verify --package mcp --artifact-manifest "${{ steps.mcp.outputs.evidence }}"',
+    ]
+    const verificationIndexes = orderedVerificationRuns.map((run) => verifyRuns.indexOf(run))
+    expect(verificationIndexes.every((index) => index >= 0)).toBe(true)
+    expect(verificationIndexes).toEqual([...verificationIndexes].sort((left, right) => left - right))
   })
 
   it('retries post-mint work against transferred bytes without rebuilding', () => {


### PR DESCRIPTION
The protected release built and byte-verified all three candidate packages, but the packed Vue consumer could not start because the candidate-verification job had not installed Chromium.

This change installs the Playwright browser before immutable candidate certification. The workflow test now enforces that order, so the missing prerequisite cannot return.

This does not change package bytes, versions, APIs, publication permissions, or provenance rules.

Verification:

- `pnpm exec vitest run test/unit/release-workflow.test.ts` — 15 tests passed
- `actionlint .github/workflows/publish-prerelease.yml`
- `pnpm check` — 174 test files and 2,060 tests passed with normal system access
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease candidate verification by installing Chromium and its required browser dependencies before verification.
  * Ensured browser setup runs before Vue candidate checks, improving reliability of release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->