### PR TITLE
fix(release): install candidate backend prerequisite

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Install the packed-consumer browser
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Install the reviewed local Convex backend
+        run: pnpm check:auth-backend --install
+
       - name: Resolve the reviewed candidate coordinates
         id: candidate_set
         run: node scripts/print-candidate-set-coordinates.mjs >> "$GITHUB_OUTPUT"

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -388,6 +388,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     const verifyRuns = runs(workflow, 'verify-candidates')
     const orderedVerificationRuns = [
       'pnpm exec playwright install --with-deps chromium',
+      'pnpm check:auth-backend --install',
       'pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"',
       'pnpm release:verify --package vue --artifact-manifest "${{ steps.vue.outputs.evidence }}"',
       'pnpm release:verify --package nuxt --artifact-manifest "${{ steps.nuxt.outputs.evidence }}"',


### PR DESCRIPTION
The protected release could certify the Vue and Nuxt candidates, but the MCP consumer stopped because a clean GitHub runner did not have the reviewed local Convex backend. The release workflow installed Chromium but omitted the other runtime prerequisite used by the existing authentication lanes.

This change installs the manifest-pinned Convex backend before any transferred candidate is certified. The existing installer verifies the downloaded binary against the committed SHA-256. The workflow contract test now enforces both clean-runner prerequisites in order.

No publication permissions, package bytes, dependency policy, or release recovery behavior changed.

Verification:

- `actionlint .github/workflows/publish-prerelease.yml`
- `pnpm exec vitest run test/unit/release-workflow.test.ts`
- `pnpm check` — 174 files and 2,060 tests passed
- `pnpm check:auth-backend --install` — pinned binary installed and verified
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease verification by installing the reviewed authentication backend before validating candidate artifacts.
  * Ensured release verification runs in the correct order for more reliable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->