### PR TITLE
fix(release): attach MCP evidence to prerelease

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -493,11 +493,11 @@ jobs:
           test "${#tarballs[@]}" -eq 3
           vue_evidence=$(find .release-artifacts -path '*/vue/*/artifact.json' -type f -print -quit)
           nuxt_evidence=$(find .release-artifacts -path '*/nuxt/*/artifact.json' -type f -print -quit)
-          mcp_evidence=$(find .release-artifacts -path '*/mcp/*/artifact.json' -type f -print -quit)
+          mcp_evidence=".release-artifacts/artifact.json"
           set_evidence=$(find .release-artifacts -name 'artifact-set.json' -type f -print -quit)
           test -n "$vue_evidence"
           test -n "$nuxt_evidence"
-          test -n "$mcp_evidence"
+          test -f "$mcp_evidence"
           test -n "$set_evidence"
           cp "$vue_evidence" "$RUNNER_TEMP/vue-artifact.json"
           cp "$nuxt_evidence" "$RUNNER_TEMP/nuxt-artifact.json"

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -579,6 +579,8 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     expect(githubReleaseRuns).toContain('gh release upload')
     expect(githubReleaseRuns).toContain('release_assets')
     expect(githubReleaseRuns).toContain('vue-nuxt-artifact-set.json')
+    expect(githubReleaseRuns).toContain('mcp_evidence=".release-artifacts/artifact.json"')
+    expect(githubReleaseRuns).toContain('test -f "$mcp_evidence"')
     expect(githubReleaseRuns).toContain('git/ref/tags/$TAG')
     expect(githubReleaseRuns).toContain('test "$tag_sha" = "$GITHUB_SHA"')
     expect(githubReleaseRuns).toContain(


### PR DESCRIPTION
The Better Convex packages were published correctly, but the automatic GitHub prerelease stopped while collecting MCP evidence. The MCP artifact downloads at the root of the retained artifact directory, while the release job searched for a nested `mcp` directory.

This change uses the actual retained MCP evidence path and requires the file to exist before creating the release. It does not rebuild or republish any package.

Verification:

- `pnpm exec vitest run test/unit/release-workflow.test.ts`
- `pnpm exec actionlint .github/workflows/publish-prerelease.yml`
- `pnpm check` — 174 test files and 2,060 tests passed outside the restricted sandbox
- `git diff --check`

Prepared with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease validation to reliably locate and verify the required release evidence artifact.

* **Tests**
  * Added coverage confirming the prerelease workflow uses the expected evidence file path and checks that the file exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->