### PR TITLE
ci(docs): cut unrelated Vercel build usage

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -2,5 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nuxtjs",
   "buildCommand": "pnpm build",
+  "git": {
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- .",
   "outputDirectory": null
 }

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
+const expectedIgnoreCommand = 'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- .'
 const failures = []
 const check = (condition, message) => {
   if (!condition) failures.push(message)
@@ -11,6 +12,8 @@ const check = (condition, message) => {
 check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deployable docs app.')
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
+check(config.git?.deploymentEnabled === true, 'Create a Vercel status for every pull-request commit.')
+check(config.ignoreCommand === expectedIgnoreCommand, 'Skip deployments that cannot affect the documentation app.')
 check(config.outputDirectory === null, 'Let Nuxt and Vercel detect .vercel/output.')
 check(config.buildCommand === 'pnpm build', 'Build the documentation app directly.')
 check(!('installCommand' in config), 'Let Vercel detect pnpm from the documentation lockfile.')

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -3,7 +3,8 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
-const expectedIgnoreCommand = 'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- .'
+const expectedIgnoreCommand =
+  'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- .'
 const failures = []
 const check = (condition, message) => {
   if (!condition) failures.push(message)
@@ -12,8 +13,14 @@ const check = (condition, message) => {
 check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deployable docs app.')
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
-check(config.git?.deploymentEnabled === true, 'Create a Vercel status for every pull-request commit.')
-check(config.ignoreCommand === expectedIgnoreCommand, 'Skip deployments that cannot affect the documentation app.')
+check(
+  config.git?.deploymentEnabled === true,
+  'Create a Vercel status for every pull-request commit.',
+)
+check(
+  config.ignoreCommand === expectedIgnoreCommand,
+  'Skip deployments that cannot affect the documentation app.',
+)
 check(config.outputDirectory === null, 'Let Nuxt and Vercel detect .vercel/output.')
 check(config.buildCommand === 'pnpm build', 'Build the documentation app directly.')
 check(!('installCommand' in config), 'Let Vercel detect pnpm from the documentation lockfile.')


### PR DESCRIPTION
The documentation project currently rebuilds on Vercel for repository changes that cannot affect the deployed site. Those unnecessary deployments consume Build CPU without improving review confidence.

This keeps Vercel connected for every pull-request commit, but skips the build when the documentation app has not changed since the branch's last successful deployment. If Vercel cannot provide that baseline, the rule safely builds instead of skipping. A repository policy assertion protects the exact contract.

Impact: changes outside the standalone `docs` app stop consuming Vercel build time after the branch's first deployment.

Verification:

- `node scripts/check-vercel-config.mjs`
- ignore-command behavior: missing baseline builds, unchanged docs skip, relevant docs commit builds
- `git diff --check`

Implemented and verified with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment configuration to support Git-based deployments.
  * Skips deployments when no changes have occurred since the previous deployment.
  * Enables deployments for pull-request commits.
  * Added validation to ensure deployment settings remain correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->