### PR TITLE
ci: classify expensive source verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,10 @@ jobs:
           SECRETS: ${{ needs.secrets.result }}
         run: |
           test "$CLASSIFY_RESULT" = success
+          case "$FULL" in
+            true | false) ;;
+            *) echo "Invalid classifier output: $FULL" >&2; exit 1 ;;
+          esac
           test "$SECRETS" = success
           test "$DEPLOYABLE_APP_AUDITS" = success
           for result in "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$RELEASE_SMOKE"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,37 @@ env:
   RELEASE_NPM_VERSION: '11.18.0'
 
 jobs:
+  classify:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+    outputs:
+      full: ${{ steps.paths.outputs.full }}
+    steps:
+      - name: Select required lanes
+        id: paths
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const runAll = context.eventName !== 'pull_request'
+            const files = runAll
+              ? []
+              : await github.paginate(github.rest.pulls.listFiles, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  per_page: 100,
+                })
+            const paths = files.map((file) => file.filename)
+            const publicDocsOnly =
+              paths.length > 0 &&
+              paths.every((path) =>
+                /^(?:docs\/|README\.md$|CONTRIBUTING\.md$|SECURITY\.md$|MAINTAINING\.md$|AGENTS\.md$|CLAUDE\.md$|LICENSE$)/u.test(path),
+              )
+            core.setOutput('full', String(runAll || !publicDocsOnly))
+
   secrets:
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +60,8 @@ jobs:
           extra_args: --only-verified
 
   compatibility:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,6 +85,8 @@ jobs:
         run: pnpm release:certify:source core
 
   auth-contracts:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,6 +107,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   auth-real-backend:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -110,6 +147,8 @@ jobs:
         run: corepack pnpm audit --prod
 
   release-smoke:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -145,6 +184,7 @@ jobs:
   release-gate:
     needs:
       [
+        classify,
         secrets,
         compatibility,
         auth-contracts,
@@ -158,6 +198,8 @@ jobs:
     steps:
       - name: Require every independent source lane
         env:
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          FULL: ${{ needs.classify.outputs.full }}
           AUTH_CONTRACTS: ${{ needs.auth-contracts.result }}
           AUTH_REAL_BACKEND: ${{ needs.auth-real-backend.result }}
           COMPATIBILITY: ${{ needs.compatibility.result }}
@@ -165,6 +207,9 @@ jobs:
           RELEASE_SMOKE: ${{ needs.release-smoke.result }}
           SECRETS: ${{ needs.secrets.result }}
         run: |
-          for result in "$SECRETS" "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$DEPLOYABLE_APP_AUDITS" "$RELEASE_SMOKE"; do
-            test "$result" = success
+          test "$CLASSIFY_RESULT" = success
+          test "$SECRETS" = success
+          test "$DEPLOYABLE_APP_AUDITS" = success
+          for result in "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$RELEASE_SMOKE"; do
+            if [ "$FULL" = true ]; then test "$result" = success; else test "$result" = skipped; fi
           done

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -279,7 +279,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     )
   })
 
-  it('keeps CI source-only and package previews non-authoritative', () => {
+  it('keeps CI source-only and package previews non-authoritative', async () => {
     expect(ciWorkflow.env?.RELEASE_NPM_VERSION).toBe('11.18.0')
     expect(preparationCommands(ciWorkflow, 'release-gate')).toEqual([])
     expect(preparationCommands(previewWorkflow, 'preview')).toEqual([])
@@ -298,6 +298,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     })
     expect(requireJob(ciWorkflow, 'release-gate')['timeout-minutes']).toBe(5)
     expect(needs(ciWorkflow, 'release-gate')).toEqual([
+      'classify',
       'secrets',
       'compatibility',
       'auth-contracts',
@@ -306,8 +307,32 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       'release-smoke',
     ])
     expect(runs(ciWorkflow, 'release-gate')).toEqual([
-      'for result in "$SECRETS" "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$DEPLOYABLE_APP_AUDITS" "$RELEASE_SMOKE"; do test "$result" = success done',
+      'test "$CLASSIFY_RESULT" = success test "$SECRETS" = success test "$DEPLOYABLE_APP_AUDITS" = success for result in "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$RELEASE_SMOKE"; do if [ "$FULL" = true ]; then test "$result" = success; else test "$result" = skipped; fi done',
     ])
+    const classifyScript = steps(ciWorkflow, 'classify').find(
+      (step) => step.name === 'Select required lanes',
+    )?.with?.script
+    if (typeof classifyScript !== 'string') throw new Error('Missing CI classifier script.')
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+      ...args: string[]
+    ) => (...args: unknown[]) => Promise<void>
+    for (const scenario of [
+      { name: 'public docs', event: 'pull_request', paths: ['docs/content/1.index.md'], full: 'false' },
+      { name: 'package source', event: 'pull_request', paths: ['packages/vue/src/index.ts'], full: 'true' },
+      { name: 'workflow policy', event: 'pull_request', paths: ['.github/workflows/ci.yml'], full: 'true' },
+      { name: 'main certification', event: 'push', paths: [], full: 'true' },
+    ]) {
+      const outputs = new Map<string, string>()
+      await new AsyncFunction('context', 'github', 'core', classifyScript)(
+        { eventName: scenario.event, issue: { number: 1 }, repo: { owner: 'lupinum-dev', repo: 'better-convex' } },
+        {
+          paginate: async () => scenario.paths.map((filename) => ({ filename })),
+          rest: { pulls: { listFiles() {} } },
+        },
+        { setOutput: (name: string, value: string) => outputs.set(name, value) },
+      )
+      expect(outputs.get('full'), scenario.name).toBe(scenario.full)
+    }
   })
 
   it('installs the independent documentation workspace before core certification', () => {

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -307,7 +307,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       'release-smoke',
     ])
     expect(runs(ciWorkflow, 'release-gate')).toEqual([
-      'test "$CLASSIFY_RESULT" = success test "$SECRETS" = success test "$DEPLOYABLE_APP_AUDITS" = success for result in "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$RELEASE_SMOKE"; do if [ "$FULL" = true ]; then test "$result" = success; else test "$result" = skipped; fi done',
+      'test "$CLASSIFY_RESULT" = success case "$FULL" in true | false) ;; *) echo "Invalid classifier output: $FULL" >&2; exit 1 ;; esac test "$SECRETS" = success test "$DEPLOYABLE_APP_AUDITS" = success for result in "$COMPATIBILITY" "$AUTH_CONTRACTS" "$AUTH_REAL_BACKEND" "$RELEASE_SMOKE"; do if [ "$FULL" = true ]; then test "$result" = success; else test "$result" = skipped; fi done',
     ])
     const classifyScript = steps(ciWorkflow, 'classify').find(
       (step) => step.name === 'Select required lanes',
@@ -327,6 +327,18 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
         name: 'package source',
         event: 'pull_request',
         paths: ['packages/vue/src/index.ts'],
+        full: 'true',
+      },
+      {
+        name: 'empty pull request',
+        event: 'pull_request',
+        paths: [],
+        full: 'true',
+      },
+      {
+        name: 'mixed public docs and source',
+        event: 'pull_request',
+        paths: ['docs/content/1.index.md', 'packages/vue/src/index.ts'],
         full: 'true',
       },
       {

--- a/test/unit/release-workflow.test.ts
+++ b/test/unit/release-workflow.test.ts
@@ -317,14 +317,33 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       ...args: string[]
     ) => (...args: unknown[]) => Promise<void>
     for (const scenario of [
-      { name: 'public docs', event: 'pull_request', paths: ['docs/content/1.index.md'], full: 'false' },
-      { name: 'package source', event: 'pull_request', paths: ['packages/vue/src/index.ts'], full: 'true' },
-      { name: 'workflow policy', event: 'pull_request', paths: ['.github/workflows/ci.yml'], full: 'true' },
+      {
+        name: 'public docs',
+        event: 'pull_request',
+        paths: ['docs/content/1.index.md'],
+        full: 'false',
+      },
+      {
+        name: 'package source',
+        event: 'pull_request',
+        paths: ['packages/vue/src/index.ts'],
+        full: 'true',
+      },
+      {
+        name: 'workflow policy',
+        event: 'pull_request',
+        paths: ['.github/workflows/ci.yml'],
+        full: 'true',
+      },
       { name: 'main certification', event: 'push', paths: [], full: 'true' },
     ]) {
       const outputs = new Map<string, string>()
       await new AsyncFunction('context', 'github', 'core', classifyScript)(
-        { eventName: scenario.event, issue: { number: 1 }, repo: { owner: 'lupinum-dev', repo: 'better-convex' } },
+        {
+          eventName: scenario.event,
+          issue: { number: 1 },
+          repo: { owner: 'lupinum-dev', repo: 'better-convex' },
+        },
         {
           paginate: async () => scenario.paths.map((filename) => ({ filename })),
           rest: { pulls: { listFiles() {} } },


### PR DESCRIPTION
Better Convex runs core certification, two auth/browser suites, and release smoke for public documentation pull requests that cannot affect package source. Secret scanning and deployable-app audits are separate boundaries and should remain active.

Classify changes in a small read-only job. Public docs skip only the four source-only lanes; secret scanning, deployable dependency audits, Vercel, and CodeQL remain active. Source, dependency, workflow, unknown, and main changes remain full, and release-gate always reports.

The existing release workflow test executes the exact classifier with independent docs, source, workflow, and main fixtures. Verified with all 15 release-workflow tests and ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration workflows to distinguish documentation-only changes from code changes.
  - Documentation-only pull requests now receive streamlined validation while still passing required release checks.
  - Code changes continue to run comprehensive compatibility, authentication, and release smoke tests.
  - Updated automated tests to verify workflow classification and release-gate behavior across supported change types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->