### PR TITLE
fix(docs): build when Vercel baseline is missing

### DIFF
--- a/docs/scripts/vercel-ignore.mjs
+++ b/docs/scripts/vercel-ignore.mjs
@@ -1,0 +1,13 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA
+
+if (!previousSha) process.exit(1)
+
+const root = resolve(import.meta.dirname, '../..')
+const git = (args) => spawnSync('git', args, { cwd: root, stdio: 'ignore' }).status ?? 1
+
+if (git(['cat-file', '-e', `${previousSha}^{commit}`]) !== 0) process.exit(1)
+
+process.exit(git(['diff', '--quiet', previousSha, 'HEAD', '--', 'docs']))

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -5,6 +5,6 @@
   "git": {
     "deploymentEnabled": true
   },
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- .",
+  "ignoreCommand": "node scripts/vercel-ignore.mjs",
   "outputDirectory": null
 }

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -1,10 +1,10 @@
+import { spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
-const expectedIgnoreCommand =
-  'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- .'
+const expectedIgnoreCommand = 'node scripts/vercel-ignore.mjs'
 const failures = []
 const check = (condition, message) => {
   if (!condition) failures.push(message)
@@ -20,6 +20,19 @@ check(
 check(
   config.ignoreCommand === expectedIgnoreCommand,
   'Skip deployments that cannot affect the documentation app.',
+)
+const runIgnoreCommand = (previousSha) =>
+  spawnSync('sh', ['-c', config.ignoreCommand], {
+    cwd: resolve(root, 'docs'),
+    env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previousSha },
+  })
+check(
+  runIgnoreCommand('0000000000000000000000000000000000000000').status === 1,
+  'Build when a rebased or force-pushed previous commit is unavailable.',
+)
+check(
+  runIgnoreCommand('HEAD').status === 0,
+  'Skip the build when documentation inputs are unchanged.',
 )
 check(config.outputDirectory === null, 'Let Nuxt and Vercel detect .vercel/output.')
 check(config.buildCommand === 'pnpm build', 'Build the documentation app directly.')


### PR DESCRIPTION
A rebased or force-updated branch can remove Vercel's stored previous commit from the checkout. The old inline diff then failed before the documentation build could start.

This moves the filter into a short committed script. It verifies the previous commit before comparing the docs boundary and safely requests a build when the baseline is unavailable.

Verified with pnpm check:vercel, both missing and unchanged baseline fixtures, the formatter, and the staged diff check.