### PR TITLE
ci(vercel): cut library preview build usage

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -21,7 +21,7 @@ jobs:
       checks: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     concurrency:
       group: vercel-preview-${{ github.repository }}-${{ github.event.issue.number }}
       cancel-in-progress: false

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -275,7 +275,10 @@ jobs:
                   { retries: 3 },
                 )
                 const existingDeployment = existingDeployments.deployments?.find(
-                  (candidate) => candidate.uid !== deployment.id && candidate.state === 'READY' && candidate.url,
+                  (candidate) =>
+                    candidate.uid !== deployment.id &&
+                    candidate.readyState === 'READY' &&
+                    candidate.url,
                 )
 
                 if (existingDeployment) {

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,115 @@
+name: Vercel preview
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: vercel-preview-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/vercel' &&
+      (github.event.comment.author_association == 'OWNER' ||
+      github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve trusted pull request
+        id: pull-request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.issue.number,
+            })
+
+            if (pullRequest.state !== 'open') {
+              throw new Error('The pull request is not open.')
+            }
+
+            if (pullRequest.head.repo.full_name !== `${owner}/${repo}`) {
+              throw new Error('Fork pull requests cannot access the Vercel deployment secret.')
+            }
+
+            core.setOutput('sha', pullRequest.head.sha)
+
+      - name: Check out pull request commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ steps.pull-request.outputs.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.18.0
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Build Vercel output on GitHub
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          test -n "$VERCEL_ORG_ID"
+          test -n "$VERCEL_PROJECT_ID"
+          test -n "$VERCEL_TOKEN"
+          pnpm dlx vercel@59.3.0 pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@59.3.0 build --token "$VERCEL_TOKEN"
+
+      - name: Upload prebuilt preview
+        id: deploy
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          deployment_url="$(pnpm dlx vercel@59.3.0 deploy --prebuilt --yes --token "$VERCEL_TOKEN")"
+          case "$deployment_url" in
+            https://*) ;;
+            *) echo "Vercel did not return a deployment URL." >&2; exit 1 ;;
+          esac
+          printf 'url=%s\n' "$deployment_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `Vercel preview: ${process.env.PREVIEW_URL}`,
+            })
+
+      - name: Comment failure
+        if: failure()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `Vercel preview failed: ${process.env.RUN_URL}`,
+            })

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -21,6 +21,7 @@ jobs:
       checks: write
       contents: read
       issues: write
+      # GitHub requires this scope to comment on pull requests.
       pull-requests: write
     concurrency:
       group: vercel-preview-${{ github.repository }}-${{ github.event.issue.number }}

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -77,6 +77,21 @@ jobs:
               })
             }
 
+            const reportBestEffort = async (label, operation) => {
+              try {
+                return await operation()
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error)
+                core.warning(`${label}: ${message}`)
+                return undefined
+              }
+            }
+
+            const reportStatusComment = (label, body) =>
+              reportBestEffort(label, () => updateStatusComment(body))
+            const updateCheckBestEffort = (label, parameters) =>
+              reportBestEffort(label, () => github.rest.checks.update(parameters))
+
             const requestVercel = async (path, options = {}, { retries = 0 } = {}) => {
               const separator = path.includes('?') ? '&' : '?'
               const url = `https://api.vercel.com${path}${separator}teamId=${encodeURIComponent(vercelOrgId)}`
@@ -207,7 +222,8 @@ jobs:
               })
 
               let inspectorUrl = absoluteUrl(deployment.inspectorUrl)
-              await updateStatusComment(
+              await reportStatusComment(
+                'Could not report the building deployment',
                 [
                   '⏳ **Vercel preview is building**',
                   '',
@@ -218,16 +234,19 @@ jobs:
                 ].join('\n'),
               )
 
-              await github.rest.checks.update({
-                owner,
-                repo,
-                check_run_id: checkRunId,
-                details_url: inspectorUrl || runUrl,
-                output: {
-                  title: 'Vercel preview is building',
-                  summary: `Vercel is building pull request #${issueNumber} at ${shortSha}.`,
+              await updateCheckBestEffort(
+                'Could not update the building check',
+                {
+                  owner,
+                  repo,
+                  check_run_id: checkRunId,
+                  details_url: inspectorUrl || runUrl,
+                  output: {
+                    title: 'Vercel preview is building',
+                    summary: `Vercel is building pull request #${issueNumber} at ${shortSha}.`,
+                  },
                 },
-              })
+              )
 
               const terminalStates = new Set(['BLOCKED', 'CANCELED', 'ERROR', 'READY'])
               const deadline = jobStart + 45 * 60 * 1000
@@ -267,7 +286,8 @@ jobs:
               }
 
               if (wasIgnored && !reusedExistingPreview) {
-                await updateStatusComment(
+                await reportStatusComment(
+                  'Could not report the skipped deployment',
                   [
                     '⏭️ **Vercel preview was not needed**',
                     '',
@@ -278,19 +298,22 @@ jobs:
                   ].join('\n'),
                 )
 
-                await github.rest.checks.update({
-                  owner,
-                  repo,
-                  check_run_id: checkRunId,
-                  status: 'completed',
-                  conclusion: 'neutral',
-                  completed_at: new Date().toISOString(),
-                  details_url: inspectorUrl || runUrl,
-                  output: {
-                    title: 'Vercel preview was not needed',
-                    summary: `Commit ${shortSha} does not change the documentation site.`,
+                await updateCheckBestEffort(
+                  'Could not complete the skipped deployment check',
+                  {
+                    owner,
+                    repo,
+                    check_run_id: checkRunId,
+                    status: 'completed',
+                    conclusion: 'neutral',
+                    completed_at: new Date().toISOString(),
+                    details_url: inspectorUrl || runUrl,
+                    output: {
+                      title: 'Vercel preview was not needed',
+                      summary: `Commit ${shortSha} does not change the documentation site.`,
+                    },
                   },
-                })
+                )
                 return
               }
 
@@ -301,17 +324,26 @@ jobs:
               const previewUrl = absoluteUrl(deployment.url)
               if (!previewUrl) throw new Error('Vercel did not return a preview URL.')
 
-              const { data: currentPullRequest } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: issueNumber,
-              })
-              const isOutdated = currentPullRequest.head.sha !== commitSha
+              const currentPullRequest = await reportBestEffort(
+                'Could not refresh the pull request before reporting the preview',
+                async () =>
+                  (
+                    await github.rest.pulls.get({
+                      owner,
+                      repo,
+                      pull_number: issueNumber,
+                    })
+                  ).data,
+              )
+              const isOutdated = currentPullRequest
+                ? currentPullRequest.head.sha !== commitSha
+                : false
               const outdatedMessage = isOutdated
                 ? `\n\n⚠️ The pull request is now at \`${currentPullRequest.head.sha.slice(0, 7)}\`. Run \`/vercel\` again for the latest commit.`
                 : ''
 
-              await updateStatusComment(
+              await reportStatusComment(
+                'Could not report the ready deployment',
                 [
                   '✅ **Vercel preview is ready**',
                   '',
@@ -324,21 +356,24 @@ jobs:
                 ].join('\n') + outdatedMessage,
               )
 
-              await github.rest.checks.update({
-                owner,
-                repo,
-                check_run_id: checkRunId,
-                status: 'completed',
-                conclusion: 'success',
-                completed_at: new Date().toISOString(),
-                details_url: previewUrl,
-                output: {
-                  title: isOutdated ? 'Preview ready for an older commit' : 'Vercel preview is ready',
-                  summary: isOutdated
-                    ? `Commit ${shortSha} deployed successfully, but the pull request has newer changes.`
-                    : `Pull request #${issueNumber} at ${shortSha} deployed successfully.`,
+              await updateCheckBestEffort(
+                'Could not complete the successful deployment check',
+                {
+                  owner,
+                  repo,
+                  check_run_id: checkRunId,
+                  status: 'completed',
+                  conclusion: 'success',
+                  completed_at: new Date().toISOString(),
+                  details_url: previewUrl,
+                  output: {
+                    title: isOutdated ? 'Preview ready for an older commit' : 'Vercel preview is ready',
+                    summary: isOutdated
+                      ? `Commit ${shortSha} deployed successfully, but the pull request has newer changes.`
+                      : `Pull request #${issueNumber} at ${shortSha} deployed successfully.`,
+                  },
                 },
-              })
+              )
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error)
               const shortSha = commitSha?.slice(0, 7)

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -206,7 +206,7 @@ jobs:
                 }),
               })
 
-              const inspectorUrl = absoluteUrl(deployment.inspectorUrl)
+              let inspectorUrl = absoluteUrl(deployment.inspectorUrl)
               await updateStatusComment(
                 [
                   '⏳ **Vercel preview is building**',
@@ -248,7 +248,25 @@ jobs:
               const wasIgnored =
                 deployment.readyState === 'CANCELED' &&
                 deployment.errorLink?.includes('ignored-build-step')
+              let reusedExistingPreview = false
               if (wasIgnored) {
+                const existingDeployments = await requestVercel(
+                  `/v7/deployments?projectId=${encodeURIComponent(vercelProjectId)}&sha=${encodeURIComponent(commitSha)}&state=READY&limit=10`,
+                  {},
+                  { retries: 3 },
+                )
+                const existingDeployment = existingDeployments.deployments?.find(
+                  (candidate) => candidate.uid !== deployment.id && candidate.state === 'READY' && candidate.url,
+                )
+
+                if (existingDeployment) {
+                  deployment = existingDeployment
+                  inspectorUrl = absoluteUrl(existingDeployment.inspectorUrl)
+                  reusedExistingPreview = true
+                }
+              }
+
+              if (wasIgnored && !reusedExistingPreview) {
                 await updateStatusComment(
                   [
                     '⏭️ **Vercel preview was not needed**',
@@ -300,7 +318,9 @@ jobs:
                   `Commit: [\`${shortSha}\`](${commitUrl})`,
                   `[Open preview](${previewUrl}) · ${inspectorUrl ? `[View build details](${inspectorUrl})` : `[View workflow](${runUrl})`}`,
                   '',
-                  'The exact pull request commit built and deployed successfully. Package checks are reported separately.',
+                  reusedExistingPreview
+                    ? 'The exact pull request commit already had a successful deployment, so Vercel reused it without rebuilding. Package checks are reported separately.'
+                    : 'The exact pull request commit built and deployed successfully. Package checks are reported separately.',
                 ].join('\n') + outdatedMessage,
               )
 

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -5,13 +5,10 @@ on:
     types: [created]
 
 permissions:
+  checks: write
   contents: read
   issues: write
   pull-requests: read
-
-concurrency:
-  group: vercel-preview-${{ github.event.issue.number }}
-  cancel-in-progress: true
 
 jobs:
   preview:
@@ -22,94 +19,288 @@ jobs:
       github.event.comment.author_association == 'MEMBER' ||
       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
+    concurrency:
+      group: vercel-preview-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
     steps:
-      - name: Resolve trusted pull request
-        id: pull-request
+      - name: Deploy exact pull request commit
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const { owner, repo } = context.repo
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: context.issue.number,
-            })
-
-            if (pullRequest.state !== 'open') {
-              throw new Error('The pull request is not open.')
-            }
-
-            if (pullRequest.head.repo.full_name !== `${owner}/${repo}`) {
-              throw new Error('Fork pull requests cannot access the Vercel deployment secret.')
-            }
-
-            core.setOutput('sha', pullRequest.head.sha)
-
-      - name: Check out pull request commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          ref: ${{ steps.pull-request.outputs.sha }}
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-        with:
-          node-version: 24.18.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Build Vercel output on GitHub
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          test -n "$VERCEL_ORG_ID"
-          test -n "$VERCEL_PROJECT_ID"
-          test -n "$VERCEL_TOKEN"
-          pnpm dlx vercel@59.3.0 pull --yes --environment=preview --token "$VERCEL_TOKEN"
-          pnpm dlx vercel@59.3.0 build --token "$VERCEL_TOKEN"
-
-      - name: Upload prebuilt preview
-        id: deploy
-        env:
-          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          deployment_url="$(pnpm dlx vercel@59.3.0 deploy --prebuilt --yes --token "$VERCEL_TOKEN")"
-          case "$deployment_url" in
-            https://*) ;;
-            *) echo "Vercel did not return a deployment URL." >&2; exit 1 ;;
-          esac
-          printf 'url=%s\n' "$deployment_url" >> "$GITHUB_OUTPUT"
-
-      - name: Comment preview URL
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         with:
           github-token: ${{ github.token }}
           script: |
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body: `Vercel preview: ${process.env.PREVIEW_URL}`,
-            })
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const issueNumber = context.issue.number
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const vercelOrgId = process.env.VERCEL_ORG_ID
+            const vercelProjectId = process.env.VERCEL_PROJECT_ID
+            const vercelToken = process.env.VERCEL_TOKEN
 
-      - name: Comment failure
-        if: failure()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body: `Vercel preview failed: ${process.env.RUN_URL}`,
-            })
+            let checkRunId
+            let commitSha
+            let deployment
+            let statusCommentId
+
+            const absoluteUrl = (value) => {
+              if (!value) return undefined
+              return value.startsWith('http://') || value.startsWith('https://')
+                ? value
+                : `https://${value}`
+            }
+
+            const updateStatusComment = async (body) => {
+              if (!statusCommentId) {
+                const { data: comment } = await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body,
+                })
+                statusCommentId = comment.id
+                return
+              }
+
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: statusCommentId,
+                body,
+              })
+            }
+
+            const requestVercel = async (path, options = {}) => {
+              const separator = path.includes('?') ? '&' : '?'
+              const response = await fetch(
+                `https://api.vercel.com${path}${separator}teamId=${encodeURIComponent(vercelOrgId)}`,
+                {
+                  ...options,
+                  headers: {
+                    Authorization: `Bearer ${vercelToken}`,
+                    'Content-Type': 'application/json',
+                    ...options.headers,
+                  },
+                },
+              )
+
+              const payload = await response.json().catch(() => ({}))
+              if (!response.ok) {
+                const apiMessage = payload.error?.message || payload.message || response.statusText
+                throw new Error(`Vercel API request failed (${response.status}): ${apiMessage}`)
+              }
+
+              return payload
+            }
+
+            try {
+              for (const [name, value] of Object.entries({
+                VERCEL_ORG_ID: vercelOrgId,
+                VERCEL_PROJECT_ID: vercelProjectId,
+                VERCEL_TOKEN: vercelToken,
+              })) {
+                if (!value) throw new Error(`${name} is not configured.`)
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issueNumber,
+              })
+
+              if (pullRequest.state !== 'open') throw new Error('The pull request is not open.')
+              if (pullRequest.head.repo?.full_name !== `${owner}/${repo}`) {
+                throw new Error('Fork pull requests cannot request a Vercel preview.')
+              }
+
+              commitSha = pullRequest.head.sha
+              const shortSha = commitSha.slice(0, 7)
+              const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${commitSha}`
+
+              await updateStatusComment(
+                [
+                  '⏳ **Vercel preview is starting**',
+                  '',
+                  `Commit: [\`${shortSha}\`](${commitUrl})`,
+                  '',
+                  'This comment will update when the deployment finishes.',
+                ].join('\n'),
+              )
+
+              const { data: checkRun } = await github.rest.checks.create({
+                owner,
+                repo,
+                name: 'Vercel Preview',
+                head_sha: commitSha,
+                status: 'in_progress',
+                started_at: new Date().toISOString(),
+                details_url: runUrl,
+                output: {
+                  title: 'Vercel preview is starting',
+                  summary: `Deploying pull request #${issueNumber} at ${shortSha}.`,
+                },
+              })
+              checkRunId = checkRun.id
+
+              deployment = await requestVercel('/v13/deployments', {
+                method: 'POST',
+                body: JSON.stringify({
+                  name: repo,
+                  project: vercelProjectId,
+                  gitSource: {
+                    type: 'github',
+                    repoId: pullRequest.head.repo.id,
+                    ref: pullRequest.head.ref,
+                    sha: commitSha,
+                  },
+                  gitMetadata: {
+                    remoteUrl: pullRequest.head.repo.html_url,
+                    commitAuthorName: pullRequest.user.login,
+                    commitMessage: pullRequest.title,
+                    commitRef: pullRequest.head.ref,
+                    commitSha,
+                    dirty: false,
+                    ci: true,
+                    ciType: 'github-actions',
+                    ciGitProviderUsername: context.actor,
+                    ciGitRepoVisibility: pullRequest.head.repo.visibility,
+                  },
+                  meta: {
+                    githubCommitOrg: owner,
+                    githubCommitRef: pullRequest.head.ref,
+                    githubCommitRepo: repo,
+                    githubCommitSha: commitSha,
+                    githubPrId: String(issueNumber),
+                    githubRepoId: String(pullRequest.head.repo.id),
+                  },
+                }),
+              })
+
+              const inspectorUrl = absoluteUrl(deployment.inspectorUrl)
+              await updateStatusComment(
+                [
+                  '⏳ **Vercel preview is building**',
+                  '',
+                  `Commit: [\`${shortSha}\`](${commitUrl})`,
+                  inspectorUrl ? `[View build details](${inspectorUrl})` : `[View workflow](${runUrl})`,
+                  '',
+                  'This comment will update when the deployment finishes.',
+                ].join('\n'),
+              )
+
+              await github.rest.checks.update({
+                owner,
+                repo,
+                check_run_id: checkRunId,
+                details_url: inspectorUrl || runUrl,
+                output: {
+                  title: 'Vercel preview is building',
+                  summary: `Vercel is building pull request #${issueNumber} at ${shortSha}.`,
+                },
+              })
+
+              const terminalStates = new Set(['BLOCKED', 'CANCELED', 'ERROR', 'READY'])
+              const deadline = Date.now() + 48 * 60 * 1000
+
+              while (!terminalStates.has(deployment.readyState)) {
+                if (Date.now() >= deadline) {
+                  throw new Error('Timed out while waiting for the Vercel deployment.')
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, 15_000))
+                deployment = await requestVercel(`/v13/deployments/${deployment.id}`)
+              }
+
+              if (deployment.readyState !== 'READY') {
+                throw new Error(`Vercel deployment finished with state ${deployment.readyState}.`)
+              }
+
+              const previewUrl = absoluteUrl(deployment.url)
+              if (!previewUrl) throw new Error('Vercel did not return a preview URL.')
+
+              const { data: currentPullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issueNumber,
+              })
+              const isOutdated = currentPullRequest.head.sha !== commitSha
+              const outdatedMessage = isOutdated
+                ? `\n\n⚠️ The pull request is now at \`${currentPullRequest.head.sha.slice(0, 7)}\`. Run \`/vercel\` again for the latest commit.`
+                : ''
+
+              await updateStatusComment(
+                [
+                  '✅ **Vercel preview is ready**',
+                  '',
+                  `Commit: [\`${shortSha}\`](${commitUrl})`,
+                  `[Open preview](${previewUrl}) · ${inspectorUrl ? `[View build details](${inspectorUrl})` : `[View workflow](${runUrl})`}`,
+                  '',
+                  'The exact pull request commit built and deployed successfully. Package checks are reported separately.',
+                ].join('\n') + outdatedMessage,
+              )
+
+              await github.rest.checks.update({
+                owner,
+                repo,
+                check_run_id: checkRunId,
+                status: 'completed',
+                conclusion: 'success',
+                completed_at: new Date().toISOString(),
+                details_url: previewUrl,
+                output: {
+                  title: isOutdated ? 'Preview ready for an older commit' : 'Vercel preview is ready',
+                  summary: isOutdated
+                    ? `Commit ${shortSha} deployed successfully, but the pull request has newer changes.`
+                    : `Pull request #${issueNumber} at ${shortSha} deployed successfully.`,
+                },
+              })
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error)
+              const shortSha = commitSha?.slice(0, 7)
+              const inspectorUrl = absoluteUrl(deployment?.inspectorUrl)
+              const commitLine = shortSha ? `Commit: \`${shortSha}\`` : undefined
+
+              try {
+                await updateStatusComment(
+                  [
+                    '❌ **Vercel preview failed**',
+                    '',
+                    commitLine,
+                    inspectorUrl ? `[View build details](${inspectorUrl})` : `[View workflow](${runUrl})`,
+                    '',
+                    'The preview did not deploy. Open the build details for the failure output.',
+                  ]
+                    .filter(Boolean)
+                    .join('\n'),
+                )
+              } catch (commentError) {
+                core.warning(`Could not update the pull request comment: ${commentError}`)
+              }
+
+              if (checkRunId) {
+                try {
+                  await github.rest.checks.update({
+                    owner,
+                    repo,
+                    check_run_id: checkRunId,
+                    status: 'completed',
+                    conclusion: 'failure',
+                    completed_at: new Date().toISOString(),
+                    details_url: inspectorUrl || runUrl,
+                    output: {
+                      title: 'Vercel preview failed',
+                      summary: shortSha
+                        ? `Pull request #${issueNumber} at ${shortSha} did not deploy.`
+                        : `Pull request #${issueNumber} did not deploy.`,
+                    },
+                  })
+                } catch (checkError) {
+                  core.warning(`Could not update the check run: ${checkError}`)
+                }
+              }
+
+              core.setFailed(message)
+            }

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -5,10 +5,7 @@ on:
     types: [created]
 
 permissions:
-  checks: write
   contents: read
-  issues: write
-  pull-requests: read
 
 jobs:
   preview:
@@ -20,12 +17,17 @@ jobs:
       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     timeout-minutes: 50
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
     concurrency:
       group: vercel-preview-${{ github.repository }}-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
       - name: Deploy exact pull request commit
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
@@ -40,6 +42,7 @@ jobs:
             const vercelOrgId = process.env.VERCEL_ORG_ID
             const vercelProjectId = process.env.VERCEL_PROJECT_ID
             const vercelToken = process.env.VERCEL_TOKEN
+            const jobStart = Date.now()
 
             let checkRunId
             let commitSha
@@ -73,27 +76,41 @@ jobs:
               })
             }
 
-            const requestVercel = async (path, options = {}) => {
+            const requestVercel = async (path, options = {}, { retries = 0 } = {}) => {
               const separator = path.includes('?') ? '&' : '?'
-              const response = await fetch(
-                `https://api.vercel.com${path}${separator}teamId=${encodeURIComponent(vercelOrgId)}`,
-                {
-                  ...options,
-                  headers: {
-                    Authorization: `Bearer ${vercelToken}`,
-                    'Content-Type': 'application/json',
-                    ...options.headers,
-                  },
-                },
-              )
+              const url = `https://api.vercel.com${path}${separator}teamId=${encodeURIComponent(vercelOrgId)}`
 
-              const payload = await response.json().catch(() => ({}))
-              if (!response.ok) {
-                const apiMessage = payload.error?.message || payload.message || response.statusText
-                throw new Error(`Vercel API request failed (${response.status}): ${apiMessage}`)
+              for (let attempt = 0; ; attempt += 1) {
+                try {
+                  const response = await fetch(url, {
+                    ...options,
+                    signal: AbortSignal.timeout(30_000),
+                    headers: {
+                      Authorization: `Bearer ${vercelToken}`,
+                      'Content-Type': 'application/json',
+                      ...options.headers,
+                    },
+                  })
+
+                  const payload = await response.json().catch(() => ({}))
+                  if (!response.ok) {
+                    const apiMessage = payload.error?.message || payload.message || response.statusText
+                    const apiError = new Error(`Vercel API request failed (${response.status}): ${apiMessage}`)
+                    apiError.retryable = response.status === 429 || response.status >= 500
+                    throw apiError
+                  }
+
+                  return payload
+                } catch (error) {
+                  const retryable =
+                    error?.retryable ||
+                    error?.name === 'TimeoutError' ||
+                    error?.name === 'AbortError' ||
+                    error instanceof TypeError
+                  if (!retryable || attempt >= retries) throw error
+                  await new Promise((resolve) => setTimeout(resolve, 5_000 * 2 ** attempt))
+                }
               }
-
-              return payload
             }
 
             try {
@@ -114,6 +131,15 @@ jobs:
               if (pullRequest.state !== 'open') throw new Error('The pull request is not open.')
               if (pullRequest.head.repo?.full_name !== `${owner}/${repo}`) {
                 throw new Error('Fork pull requests cannot request a Vercel preview.')
+              }
+
+              const { data: actorPermission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: context.actor,
+              })
+              if (!new Set(['admin', 'maintain', 'write']).has(actorPermission.permission)) {
+                throw new Error('A write-level repository role is required to request a Vercel preview.')
               }
 
               commitSha = pullRequest.head.sha
@@ -203,7 +229,7 @@ jobs:
               })
 
               const terminalStates = new Set(['BLOCKED', 'CANCELED', 'ERROR', 'READY'])
-              const deadline = Date.now() + 48 * 60 * 1000
+              const deadline = jobStart + 45 * 60 * 1000
 
               while (!terminalStates.has(deployment.readyState)) {
                 if (Date.now() >= deadline) {
@@ -211,7 +237,42 @@ jobs:
                 }
 
                 await new Promise((resolve) => setTimeout(resolve, 15_000))
-                deployment = await requestVercel(`/v13/deployments/${deployment.id}`)
+                deployment = await requestVercel(
+                  `/v13/deployments/${deployment.id}`,
+                  {},
+                  { retries: 3 },
+                )
+              }
+
+              const wasIgnored =
+                deployment.readyState === 'CANCELED' &&
+                deployment.errorLink?.includes('ignored-build-step')
+              if (wasIgnored) {
+                await updateStatusComment(
+                  [
+                    '⏭️ **Vercel preview was not needed**',
+                    '',
+                    `Commit: [\`${shortSha}\`](${commitUrl})`,
+                    inspectorUrl ? `[View build details](${inspectorUrl})` : `[View workflow](${runUrl})`,
+                    '',
+                    'Vercel found no changes that affect the documentation site. Package checks are reported separately.',
+                  ].join('\n'),
+                )
+
+                await github.rest.checks.update({
+                  owner,
+                  repo,
+                  check_run_id: checkRunId,
+                  status: 'completed',
+                  conclusion: 'neutral',
+                  completed_at: new Date().toISOString(),
+                  details_url: inspectorUrl || runUrl,
+                  output: {
+                    title: 'Vercel preview was not needed',
+                    summary: `Commit ${shortSha} does not change the documentation site.`,
+                  },
+                })
+                return
               }
 
               if (deployment.readyState !== 'READY') {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "pnpm build",
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "main": true
     }
   },

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -3,7 +3,10 @@
   "framework": "nuxtjs",
   "buildCommand": "pnpm build",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
   },
   "ignoreCommand": "node scripts/vercel-ignore.mjs",
   "outputDirectory": null

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -2,9 +2,14 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import { parse } from 'yaml'
+
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
 const previewWorkflow = readFileSync(resolve(root, '.github/workflows/vercel-preview.yml'), 'utf8')
+const previewConfig = parse(previewWorkflow)
+const previewSteps = Object.values(previewConfig.jobs ?? {}).flatMap((job) => job.steps ?? [])
+const approvedPreviewAction = 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd'
 const expectedIgnoreCommand = 'node scripts/vercel-ignore.mjs'
 const failures = []
 const check = (condition, message) => {
@@ -32,10 +37,18 @@ check(
   'Keep preview authorization, API resilience, exact-SHA reuse, and neutral skip handling.',
 )
 check(
-  !/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s*(?:-\s*)?run:/mu.test(
-    previewWorkflow,
-  ),
-  'The token-holding preview workflow must not execute pull-request code.',
+  previewSteps.length === 1 &&
+    previewSteps.every(
+      (step) =>
+        !Object.hasOwn(step, 'run') &&
+        Object.hasOwn(step, 'uses') &&
+        step.uses === approvedPreviewAction,
+    ),
+  'The token-holding preview workflow must use only the approved pinned reporting action.',
+)
+check(
+  !/vercel build|vercel deploy|pnpm install/u.test(previewWorkflow),
+  'The token-holding preview workflow must not invoke local deployment commands.',
 )
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -13,9 +13,15 @@ const check = (condition, message) => {
 
 check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deployable docs app.')
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
-check(previewWorkflow.includes("'/v13/deployments'"), 'Create previews through the Vercel deployment API.')
-check(previewWorkflow.includes('checks: write') && previewWorkflow.includes('cancel-in-progress: false'), 'Report exact-commit preview status without canceling requested builds.')
-check(!/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s+run:/mu.test(previewWorkflow), 'The token-holding preview workflow must not execute pull-request code.')
+check(previewWorkflow.includes('/v13/deployments'), 'Create previews through the Vercel deployment API.')
+check(
+  previewWorkflow.includes('checks: write') && previewWorkflow.includes('cancel-in-progress: false'),
+  'Report exact-commit preview status without canceling requested builds.',
+)
+check(
+  !/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s+run:/mu.test(previewWorkflow),
+  'The token-holding preview workflow must not execute pull-request code.',
+)
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(
   config.git?.deploymentEnabled?.['*'] === false &&

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const config = JSON.parse(readFileSync(resolve(root, 'docs/vercel.json'), 'utf8'))
+const previewWorkflow = readFileSync(resolve(root, '.github/workflows/vercel-preview.yml'), 'utf8')
 const expectedIgnoreCommand = 'node scripts/vercel-ignore.mjs'
 const failures = []
 const check = (condition, message) => {
@@ -12,6 +13,9 @@ const check = (condition, message) => {
 
 check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deployable docs app.')
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
+check(previewWorkflow.includes("'/v13/deployments'"), 'Create previews through the Vercel deployment API.')
+check(previewWorkflow.includes('checks: write') && previewWorkflow.includes('cancel-in-progress: false'), 'Report exact-commit preview status without canceling requested builds.')
+check(!/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s+run:/mu.test(previewWorkflow), 'The token-holding preview workflow must not execute pull-request code.')
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(
   config.git?.deploymentEnabled?.['*'] === false &&

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -33,6 +33,8 @@ check(
     'AbortSignal.timeout',
     'ignored-build-step',
     'reusedExistingPreview',
+    'sha=${encodeURIComponent(commitSha)}&state=READY',
+    'reportBestEffort',
   ].every((boundary) => previewWorkflow.includes(boundary)),
   'Keep preview authorization, API resilience, exact-SHA reuse, and neutral skip handling.',
 )

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -34,6 +34,7 @@ check(
     'ignored-build-step',
     'reusedExistingPreview',
     'sha=${encodeURIComponent(commitSha)}&state=READY',
+    "candidate.readyState === 'READY'",
     'reportBestEffort',
   ].every((boundary) => previewWorkflow.includes(boundary)),
   'Keep preview authorization, API resilience, exact-SHA reuse, and neutral skip handling.',

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -13,9 +13,13 @@ const check = (condition, message) => {
 
 check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deployable docs app.')
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
-check(previewWorkflow.includes('/v13/deployments'), 'Create previews through the Vercel deployment API.')
 check(
-  previewWorkflow.includes('checks: write') && previewWorkflow.includes('cancel-in-progress: false'),
+  previewWorkflow.includes('/v13/deployments'),
+  'Create previews through the Vercel deployment API.',
+)
+check(
+  previewWorkflow.includes('checks: write') &&
+    previewWorkflow.includes('cancel-in-progress: false'),
   'Report exact-commit preview status without canceling requested builds.',
 )
 check(

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -23,10 +23,10 @@ check(
   'Report exact-commit preview status without canceling requested builds.',
 )
 check(
-  ['getCollaboratorPermissionLevel', 'AbortSignal.timeout', 'ignored-build-step'].every(
+  ['getCollaboratorPermissionLevel', 'AbortSignal.timeout', 'ignored-build-step', 'reusedExistingPreview'].every(
     (boundary) => previewWorkflow.includes(boundary),
   ),
-  'Keep preview authorization, API resilience, and neutral skip handling.',
+  'Keep preview authorization, API resilience, exact-SHA reuse, and neutral skip handling.',
 )
 check(
   !/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s*(?:-\s*)?run:/mu.test(

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -36,7 +36,7 @@ check(
 )
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(
-  config.git?.deploymentEnabled?.['*'] === false &&
+  config.git?.deploymentEnabled?.['**'] === false &&
     config.git.deploymentEnabled.main === true &&
     Object.keys(config.git.deploymentEnabled).length === 2,
   'Deploy main automatically and require /vercel for pull-request previews.',

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -14,8 +14,10 @@ check(!existsSync(resolve(root, 'vercel.json')), 'Keep vercel.json in the deploy
 check(!existsSync(resolve(root, 'demo/vercel.json')), 'The example application must not deploy.')
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')
 check(
-  config.git?.deploymentEnabled === true,
-  'Create a Vercel status for every pull-request commit.',
+  config.git?.deploymentEnabled?.['*'] === false &&
+    config.git.deploymentEnabled.main === true &&
+    Object.keys(config.git.deploymentEnabled).length === 2,
+  'Deploy main automatically and require /vercel for pull-request previews.',
 )
 check(
   config.ignoreCommand === expectedIgnoreCommand,

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -23,9 +23,12 @@ check(
   'Report exact-commit preview status without canceling requested builds.',
 )
 check(
-  ['getCollaboratorPermissionLevel', 'AbortSignal.timeout', 'ignored-build-step', 'reusedExistingPreview'].every(
-    (boundary) => previewWorkflow.includes(boundary),
-  ),
+  [
+    'getCollaboratorPermissionLevel',
+    'AbortSignal.timeout',
+    'ignored-build-step',
+    'reusedExistingPreview',
+  ].every((boundary) => previewWorkflow.includes(boundary)),
   'Keep preview authorization, API resilience, exact-SHA reuse, and neutral skip handling.',
 )
 check(

--- a/scripts/check-vercel-config.mjs
+++ b/scripts/check-vercel-config.mjs
@@ -23,7 +23,15 @@ check(
   'Report exact-commit preview status without canceling requested builds.',
 )
 check(
-  !/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s+run:/mu.test(previewWorkflow),
+  ['getCollaboratorPermissionLevel', 'AbortSignal.timeout', 'ignored-build-step'].every(
+    (boundary) => previewWorkflow.includes(boundary),
+  ),
+  'Keep preview authorization, API resilience, and neutral skip handling.',
+)
+check(
+  !/actions\/checkout@|vercel build|vercel deploy|pnpm install|^\s*(?:-\s*)?run:/mu.test(
+    previewWorkflow,
+  ),
   'The token-holding preview workflow must not execute pull-request code.',
 )
 check(config.framework === 'nuxtjs', 'Select the Nuxt framework explicitly.')


### PR DESCRIPTION
Every branch push was starting a documentation preview build, so frequent agent iterations multiplied Vercel usage even when nobody needed a preview.

This keeps automatic production deployments on `main` and requires a trusted maintainer to comment exactly `/vercel` when a PR preview is useful. Vercel builds the exact PR commit through its deployment API. The GitHub job never checks out or executes PR code while holding the Vercel token.

The PR receives:

- an immediate starting/building comment;
- a `Vercel Preview` check on the exact commit;
- a clickable preview URL and build-details link on success;
- a neutral result when no site-affecting files changed;
- a failure result with build details; and
- a warning when the PR changed while the preview was building.

Security and reliability:

- the commenter must have write, maintain, or admin repository access;
- fork PRs are rejected;
- each repository uses its own project-scoped token;
- write permissions are scoped to the preview job;
- the token job performs API calls only;
- polling has bounded timeouts and retries, while deployment creation is never retried;
- requested builds queue instead of canceling each other; and
- repository policy tests preserve these boundaries.

Cost controls:

- automatic Git deployment is enabled only for `main`;
- the live project uses fixed Standard builds;
- Elastic selection and on-demand concurrency are disabled.

After this merges, comment `/vercel` on an open same-repository PR. Package CI remains separate and production still deploys automatically after merge.

Verification:

- repository Vercel policy check;
- workflow YAML and embedded JavaScript syntax;
- immutable Action SHAs;
- live Vercel settings read back as Standard, fixed, on-demand concurrency off;
- GitHub secret and project variables present without exposing values.

Release note: CI and deployment automation only; no package release or changeset.

Risk and rollback: a malformed command workflow could block manual previews, but cannot block package CI or production deploys. Revert the workflow/config commits to restore the previous behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorized pull request contributors can request a Vercel preview by commenting `/vercel`.
  * Preview status and deployment results are reported directly on the pull request.
  * Successful deployments provide a shareable preview URL for the exact pull request version.

* **Configuration**
  * Automatic deployments are disabled for other branches and enabled only for `main`.
  * Preview requests validate pull request and deployment conditions before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->