### PR TITLE
ci(release): support stable family releases

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -4,9 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Exact Nuxt and Vue prerelease version
+        description: Exact version of the selected release target
         required: true
         type: string
+      target:
+        description: Coupled Vue/Nuxt set or independently versioned MCP package
+        required: true
+        default: vue-nuxt
+        type: choice
+        options:
+          - vue-nuxt
+          - mcp
       bootstrap_packages:
         description: Comma-separated packages explicitly authorized for first-version bootstrap recovery
         required: false
@@ -22,7 +30,6 @@ permissions:
   contents: read
 
 env:
-  BCN_RELEASE_DIST_TAG: next
   RELEASE_NODE_VERSION: '22.14.0'
   RELEASE_NPM_VERSION: '11.18.0'
 
@@ -39,24 +46,32 @@ jobs:
         with:
           node-version: ${{ env.RELEASE_NODE_VERSION }}
           package-manager-cache: false
-      - name: Require current main and the exact prerelease version
+      - name: Require current main and the exact target version
         env:
           BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TARGET: ${{ inputs.target }}
         run: |
           test "$GITHUB_REF" = refs/heads/main
-          test "$(node -p "require('./package.json').version")" = "$RELEASE_VERSION"
-          case "$RELEASE_VERSION" in *-*) ;; *) exit 1 ;; esac
+          if [ "$RELEASE_TARGET" = vue-nuxt ]; then
+            test "$(node -p "require('./package.json').version")" = "$RELEASE_VERSION"
+          elif [ "$RELEASE_TARGET" = mcp ]; then
+            test "$(node -p "require('./packages/mcp/package.json').version")" = "$RELEASE_VERSION"
+          else
+            exit 1
+          fi
           node -e "const allowed=new Set(['@lupinum/better-convex-vue','@lupinum/better-convex-nuxt','@lupinum/better-convex-mcp']); const requested=(process.env.BOOTSTRAP_PACKAGES||'').split(',').map(value=>value.trim()).filter(Boolean); if(new Set(requested).size!==requested.length||requested.some(name=>!allowed.has(name))) throw new Error('bootstrap_packages must contain unique Better Convex package names.')"
       - name: Require an unused release tag
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TARGET: ${{ inputs.target }}
         run: |
+          if [ "$RELEASE_TARGET" = mcp ]; then TAG="mcp-v$RELEASE_VERSION"; else TAG="v$RELEASE_VERSION"; fi
           status=$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
             --header "Authorization: Bearer $GH_TOKEN" \
             --header "Accept: application/vnd.github+json" \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/ref/tags/v$RELEASE_VERSION")
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG")
           test "$status" = 404
       - run: npm install --global npm@"$RELEASE_NPM_VERSION" corepack@0.34.5 && corepack enable
       - run: pnpm install --frozen-lockfile
@@ -84,6 +99,8 @@ jobs:
     needs: release-security
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      BCN_RELEASE_TARGET: ${{ inputs.target }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -98,12 +115,13 @@ jobs:
       - name: Install pinned release tooling
         run: npm install --global npm@"$RELEASE_NPM_VERSION" corepack@0.34.5 && corepack enable
 
-      - name: Verify protected prerelease identity
+      - name: Verify protected release identity
         env:
           BCN_GOVERNANCE_MODE: solo-maintainer
           RELEASE_OWNER: ${{ github.actor }}
-          RELEASE_TAG: v${{ inputs.version }}
-        run: pnpm check:security-governance --prerelease
+          RELEASE_TAG: ${{ inputs.target == 'mcp' && format('mcp-v{0}', inputs.version) || format('v{0}', inputs.version) }}
+          RELEASE_TARGET: ${{ inputs.target }}
+        run: pnpm check:security-governance --release
 
       - run: pnpm install --frozen-lockfile
 
@@ -132,6 +150,10 @@ jobs:
 
       - name: Build the immutable MCP candidate once
         run: node scripts/release.mjs artifact --package mcp
+
+      - name: Retain independently versioned MCP release notes
+        if: inputs.target == 'mcp'
+        run: node scripts/release-target.mjs write-mcp-metadata
 
       - name: Upload the immutable MCP candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -376,6 +398,7 @@ jobs:
           const hasAttestations = value => Array.isArray(value)
             ? value.length > 0
             : Boolean(value && typeof value === 'object' && Object.keys(value).length > 0)
+          const releaseChannel = version => version.includes('-') ? 'next' : 'latest'
           const normalizeVersions = value => value == null ? [] : Array.isArray(value) ? value : [value]
           const modes = new Map()
           const pollAttempts = Number(process.env.REGISTRY_POLL_ATTEMPTS ?? 240)
@@ -389,6 +412,7 @@ jobs:
             const candidate = evidenceByPackage.get(packageName)
             if (!candidate || candidate.id !== id) fail(`Missing certified ${id} package.`)
             const spec = `${packageName}@${candidate.version}`
+            const channelName = releaseChannel(candidate.version)
             const existing = view(spec, 'dist.integrity')
             if (existing && existing !== candidate.integrity) fail(`${spec} exists with different bytes.`)
             let mode
@@ -405,7 +429,7 @@ jobs:
             } else {
               const result = run([
                 'publish', candidate.tarball, '--access', 'public',
-                '--tag', process.env.BCN_RELEASE_DIST_TAG,
+                '--tag', channelName,
                 '--ignore-scripts', '--provenance',
               ], true)
               if (result.status !== 0) fail(`npm publish failed for ${spec}.`)
@@ -414,7 +438,7 @@ jobs:
             while (true) {
               const registryIntegrity = view(spec, 'dist.integrity')
               const attestations = view(spec, 'dist.attestations')
-              const channel = view(packageName, `dist-tags.${process.env.BCN_RELEASE_DIST_TAG}`)
+              const channel = view(packageName, `dist-tags.${channelName}`)
               const versions = mode === 'bootstrap'
                 ? normalizeVersions(view(packageName, 'versions'))
                 : []
@@ -434,7 +458,7 @@ jobs:
               remainingPollRetries -= 1
               Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, pollDelayMs)
             }
-            if (!modes.has(id)) fail(`${spec} did not expose the required bytes, provenance mode, and ${process.env.BCN_RELEASE_DIST_TAG}.`)
+            if (!modes.has(id)) fail(`${spec} did not expose the required bytes, provenance mode, and ${channelName}.`)
           }
           for (const [id] of expectedOrder) {
             const mode = modes.get(id)
@@ -467,11 +491,18 @@ jobs:
           VUE_MODE: ${{ needs.publish-packages.outputs.vue-mode }}
           NUXT_MODE: ${{ needs.publish-packages.outputs.nuxt-mode }}
           MCP_MODE: ${{ needs.publish-packages.outputs.mcp-mode }}
-          TAG: v${{ inputs.version }}
+          RELEASE_TARGET: ${{ inputs.target }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          release_metadata=$(find .release-artifacts -name 'release.json' -type f -print -quit)
+          if [ "$RELEASE_TARGET" = mcp ]; then
+            TAG="mcp-v$VERSION"
+            release_metadata=$(find .release-artifacts -name 'mcp-release.json' -type f -print -quit)
+          else
+            TAG="v$VERSION"
+            release_metadata=$(find .release-artifacts -name 'release.json' -type f -print -quit)
+          fi
+          export TAG
           test -n "$release_metadata"
           RELEASE_METADATA="$release_metadata" RELEASE_NOTES="$RUNNER_TEMP/release-notes.md" node --input-type=module <<'NODE'
           import { readFileSync, writeFileSync } from 'node:fs'
@@ -523,6 +554,11 @@ jobs:
             "$RUNNER_TEMP/vue-nuxt-artifact-set.json"
             "$RUNNER_TEMP/release.json"
           )
+          release_flags=()
+          edit_flags=(--prerelease=false)
+          case "$VERSION" in
+            *-*) release_flags+=(--prerelease); edit_flags=(--prerelease) ;;
+          esac
           if gh release view "$TAG" >/dev/null 2>&1; then
             read -r tag_type tag_sha < <(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '[.object.type, .object.sha] | @tsv')
             while [ "$tag_type" = tag ]; do
@@ -530,8 +566,8 @@ jobs:
             done
             test "$tag_type" = commit
             test "$tag_sha" = "$GITHUB_SHA"
-            gh release edit "$TAG" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+            gh release edit "$TAG" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" "${edit_flags[@]}"
             gh release upload "$TAG" "${release_assets[@]}" --clobber
           else
-            gh release create "$TAG" "${release_assets[@]}" --target "$GITHUB_SHA" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+            gh release create "$TAG" "${release_assets[@]}" --target "$GITHUB_SHA" --title "Better Convex $TAG" --notes-file "$RUNNER_TEMP/release-notes.md" "${release_flags[@]}"
           fi

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -126,13 +126,16 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve the reviewed Vue/Nuxt candidate-set coordinates
+        if: inputs.target == 'vue-nuxt'
         id: candidate_set
         run: node scripts/print-candidate-set-coordinates.mjs >> "$GITHUB_OUTPUT"
 
       - name: Build the immutable Vue/Nuxt candidate set once
+        if: inputs.target == 'vue-nuxt'
         run: pnpm release:artifact:set
 
       - name: Upload the immutable Vue/Nuxt candidate set
+        if: inputs.target == 'vue-nuxt'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.candidate_set.outputs.artifact_name }}
@@ -145,10 +148,12 @@ jobs:
           retention-days: 90
 
       - name: Resolve the reviewed MCP artifact coordinates
+        if: inputs.target == 'mcp'
         id: mcp
         run: node scripts/print-package-artifact-coordinates.mjs --package mcp >> "$GITHUB_OUTPUT"
 
       - name: Build the immutable MCP candidate once
+        if: inputs.target == 'mcp'
         run: node scripts/release.mjs artifact --package mcp
 
       - name: Retain independently versioned MCP release notes
@@ -156,6 +161,7 @@ jobs:
         run: node scripts/release-target.mjs write-mcp-metadata
 
       - name: Upload the immutable MCP candidate
+        if: inputs.target == 'mcp'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.mcp.outputs.artifact_name }}
@@ -220,39 +226,47 @@ jobs:
         run: pnpm check:auth-backend --install
 
       - name: Resolve the reviewed candidate coordinates
+        if: inputs.target == 'vue-nuxt'
         id: candidate_set
         run: node scripts/print-candidate-set-coordinates.mjs >> "$GITHUB_OUTPUT"
 
       - name: Resolve the reviewed MCP coordinates
+        if: inputs.target == 'mcp'
         id: mcp
         run: node scripts/print-package-artifact-coordinates.mjs --package mcp >> "$GITHUB_OUTPUT"
 
       - name: Resolve the reviewed Vue coordinates
+        if: inputs.target == 'vue-nuxt'
         id: vue
         run: node scripts/print-package-artifact-coordinates.mjs --package vue >> "$GITHUB_OUTPUT"
 
       - name: Resolve the reviewed Nuxt coordinates
+        if: inputs.target == 'vue-nuxt'
         id: nuxt
         run: node scripts/print-package-artifact-coordinates.mjs --package nuxt >> "$GITHUB_OUTPUT"
 
       - name: Download the exact Vue/Nuxt candidate set
+        if: inputs.target == 'vue-nuxt'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ steps.candidate_set.outputs.artifact_name }}
           path: ${{ steps.candidate_set.outputs.directory }}
 
       - name: Download the exact MCP candidate
+        if: inputs.target == 'mcp'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ steps.mcp.outputs.artifact_name }}
           path: ${{ steps.mcp.outputs.directory }}
 
       - name: Verify the exact Vue/Nuxt candidate set bytes
+        if: inputs.target == 'vue-nuxt'
         run: pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Certify the exact Vue candidate
+        if: inputs.target == 'vue-nuxt'
         run: >-
           pnpm release:verify
           --package vue
@@ -261,6 +275,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Certify the exact Nuxt candidate
+        if: inputs.target == 'vue-nuxt'
         run: >-
           pnpm release:verify
           --package nuxt
@@ -269,6 +284,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Verify the exact MCP candidate bytes
+        if: inputs.target == 'mcp'
         run: >-
           pnpm release:verify
           --package mcp
@@ -304,11 +320,13 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - name: Download the verified Vue and Nuxt artifact set
+        if: inputs.target == 'vue-nuxt'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-candidate-vue-nuxt-set
           path: .release-artifacts
       - name: Download the verified MCP artifact
+        if: inputs.target == 'mcp'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-candidate-mcp
@@ -318,6 +336,7 @@ jobs:
         env:
           BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TARGET: ${{ inputs.target }}
         run: |
           node --input-type=module <<'NODE'
           import { spawnSync } from 'node:child_process'
@@ -326,11 +345,14 @@ jobs:
           import { basename, dirname, join } from 'node:path'
 
           const fail = message => { throw new Error(message) }
-          const expectedOrder = [
+          const packageOrder = [
             ['vue', '@lupinum/better-convex-vue'],
             ['nuxt', '@lupinum/better-convex-nuxt'],
             ['mcp', '@lupinum/better-convex-mcp'],
           ]
+          const expectedOrder = process.env.RELEASE_TARGET === 'mcp'
+            ? packageOrder.filter(([id]) => id === 'mcp')
+            : packageOrder.filter(([id]) => id !== 'mcp')
           const allowed = new Set(expectedOrder.map(([, packageName]) => packageName))
           const requested = (process.env.BOOTSTRAP_PACKAGES ?? '')
             .split(',').map(value => value.trim()).filter(Boolean)
@@ -476,11 +498,13 @@ jobs:
       contents: write
     steps:
       - name: Download the verified Vue and Nuxt artifact set
+        if: inputs.target == 'vue-nuxt'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-candidate-vue-nuxt-set
           path: .release-artifacts
       - name: Download the verified MCP artifact
+        if: inputs.target == 'mcp'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-candidate-mcp
@@ -532,28 +556,31 @@ jobs:
             printf '> Bootstrap packages: %s\n' "$bootstrap_list" >> "$RUNNER_TEMP/release-notes.md"
           fi
           mapfile -t tarballs < <(find .release-artifacts -type f -name '*.tgz' | sort)
-          test "${#tarballs[@]}" -eq 3
-          vue_evidence=$(find .release-artifacts -path '*/vue/*/artifact.json' -type f -print -quit)
-          nuxt_evidence=$(find .release-artifacts -path '*/nuxt/*/artifact.json' -type f -print -quit)
-          mcp_evidence=".release-artifacts/artifact.json"
-          set_evidence=$(find .release-artifacts -name 'artifact-set.json' -type f -print -quit)
-          test -n "$vue_evidence"
-          test -n "$nuxt_evidence"
-          test -f "$mcp_evidence"
-          test -n "$set_evidence"
-          cp "$vue_evidence" "$RUNNER_TEMP/vue-artifact.json"
-          cp "$nuxt_evidence" "$RUNNER_TEMP/nuxt-artifact.json"
-          cp "$mcp_evidence" "$RUNNER_TEMP/mcp-artifact.json"
-          cp "$set_evidence" "$RUNNER_TEMP/vue-nuxt-artifact-set.json"
           cp "$release_metadata" "$RUNNER_TEMP/release.json"
-          release_assets=(
-            "${tarballs[@]}"
-            "$RUNNER_TEMP/vue-artifact.json"
-            "$RUNNER_TEMP/nuxt-artifact.json"
-            "$RUNNER_TEMP/mcp-artifact.json"
-            "$RUNNER_TEMP/vue-nuxt-artifact-set.json"
-            "$RUNNER_TEMP/release.json"
-          )
+          release_assets=("${tarballs[@]}" "$RUNNER_TEMP/release.json")
+          if [ "$RELEASE_TARGET" = mcp ]; then
+            test "${#tarballs[@]}" -eq 1
+            mcp_evidence=".release-artifacts/artifact.json"
+            test -f "$mcp_evidence"
+            cp "$mcp_evidence" "$RUNNER_TEMP/mcp-artifact.json"
+            release_assets+=("$RUNNER_TEMP/mcp-artifact.json")
+          else
+            test "${#tarballs[@]}" -eq 2
+            vue_evidence=$(find .release-artifacts -path '*/vue/*/artifact.json' -type f -print -quit)
+            nuxt_evidence=$(find .release-artifacts -path '*/nuxt/*/artifact.json' -type f -print -quit)
+            set_evidence=$(find .release-artifacts -name 'artifact-set.json' -type f -print -quit)
+            test -n "$vue_evidence"
+            test -n "$nuxt_evidence"
+            test -n "$set_evidence"
+            cp "$vue_evidence" "$RUNNER_TEMP/vue-artifact.json"
+            cp "$nuxt_evidence" "$RUNNER_TEMP/nuxt-artifact.json"
+            cp "$set_evidence" "$RUNNER_TEMP/vue-nuxt-artifact-set.json"
+            release_assets+=(
+              "$RUNNER_TEMP/vue-artifact.json"
+              "$RUNNER_TEMP/nuxt-artifact.json"
+              "$RUNNER_TEMP/vue-nuxt-artifact-set.json"
+            )
+          fi
           release_flags=()
           edit_flags=(--prerelease=false)
           case "$VERSION" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.0.0-beta.1
 
+- Support stable `latest` releases and independent `mcp-v*` releases without
+  changing the trusted publishing workflow identity or rebuilding artifacts.
 - Align `@lupinum/better-convex-nuxt`, `@lupinum/better-convex-vue`, and
   `@lupinum/better-convex-mcp` on the first 1.0 beta contract.
 - Replace the old auth export paths and separate executables with the focused

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -132,19 +132,20 @@ exist and npm therefore rejects its trusted-publisher configuration.
 
 1. Dispatch the protected workflow with all missing packages listed in
    `bootstrap_packages`.
-2. Wait for the workflow to retain and verify all three artifacts. Do not
+2. Wait for the workflow to retain and verify the selected target artifacts. Do not
    approve the `npm` environment yet.
-3. Download the three retained tarballs and their evidence from that exact
+3. Download the retained tarball or tarballs and their evidence from that exact
    workflow run.
 4. Verify each tarball against its retained SHA-256 and SRI. Do not run
    `npm pack` or rebuild any package.
 5. Confirm that the owning npm account requires two-factor authentication for
    authorization and writes. Do not use an access token that bypasses two-factor
    authentication.
-6. Sign in to npm with that account. Publish each exact file with
-   `--access public --tag next --ignore-scripts`. Let npm request the one-time
-   password interactively for every publication. Do not put a one-time password
-   in a command, shell history, script, or log.
+6. Sign in to npm with that account. Publish each exact file with `--access
+public --tag <channel> --ignore-scripts`, where `<channel>` is `latest` for
+   a stable version and `next` for a prerelease. Let npm request the one-time
+   password interactively for every publication. Do not put a one-time
+   password in a command, shell history, script, or log.
 7. Configure each package's trusted publisher for
    `publish-prerelease.yml` and the protected `npm` environment.
 8. Approve the waiting `npm` environment.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ version of each new package therefore has one narrow exception: after the
 protected workflow certifies and retains the exact tarball, the owning human
 may publish that file once with two-factor authentication. Do not rebuild or
 repack it. The protected workflow must then verify the registry bytes and
-create the Git tag and GitHub prerelease. Later versions have no workstation
+create the Git tag and GitHub Release. Later versions have no workstation
 publication path.
 
 ## The one release path
@@ -22,10 +22,11 @@ The order is fixed:
    commit.
 3. Mint the Vue, Nuxt, and MCP artifacts once.
 4. Verify only those artifact bytes and clean consumers.
-5. Publish through npm trusted publishing under `next`, or complete the
+5. Publish through npm trusted publishing under the channel derived from each
+   package version (`latest` for stable, `next` for prerelease), or complete the
    first-package bootstrap described below.
 6. Download each package from npm and compare it with the certified SRI.
-7. Create the Git tag and GitHub prerelease from the matching changelog entry.
+7. Create the Git tag and GitHub Release from the matching changelog entry.
 
 Source certification never runs after immutable minting. Artifact verification
 never invokes the full source suite. A generic Vercel preview is a developer
@@ -67,8 +68,10 @@ Linux jobs run the core, auth, end-to-end, and secret-scanning lanes in
 parallel. `release-gate` is a small fail-closed aggregator: it succeeds only
 when every lane succeeds.
 
-The protected workflow is dispatched from `main` with the exact Nuxt and Vue
-prerelease version. It reads GitHub's check-run API and requires a successful
+The protected workflow is dispatched from `main` with `vue-nuxt` or `mcp` and
+that target's exact version. Vue and Nuxt share the root version and `v<version>`
+tag. MCP can move independently and uses `mcp-v<version>`. The workflow reads
+GitHub's check-run API and requires a successful
 `release-gate` produced by GitHub Actions for the exact dispatch commit. It does
 not rerun those source suites.
 
@@ -118,9 +121,9 @@ scripts. The job does not check out the repository, install dependencies, or
 run repository code.
 
 The job reads npm after each publish and requires the certified integrity,
-provenance mode, and `next` tag. Clean registry-consumer tests run before this
-protected job against the exact candidate tarballs. A stable workflow may use
-`latest` only after a separate stable-release review.
+provenance mode, and version-derived channel. Clean registry-consumer tests run
+before this protected job against the exact candidate tarballs. Stable package
+versions use `latest`; prerelease package versions use `next`.
 
 ## First-package bootstrap
 
@@ -147,8 +150,8 @@ exist and npm therefore rejects its trusted-publisher configuration.
 8. Approve the waiting `npm` environment.
 
 The workflow must detect the existing versions, require registry SRI equality,
-verify `next`, record each lane as `bootstrap`, and create the Git tag and
-GitHub prerelease from the certified source commit. The first versions do not
+verify the version-derived channel, record each lane as `bootstrap`, and create
+the Git tag and GitHub Release from the certified source commit. The first versions do not
 have GitHub OIDC provenance. This is a recorded npm bootstrap limitation, not
 permission to publish another version from a workstation.
 
@@ -180,7 +183,7 @@ version remains that package's sole published version and the dispatch names
 that package in `bootstrap_packages`. This explicit input authorizes only the
 known first-version recovery. Every other missing-provenance state stops the
 workflow. The workflow records each lane as `bootstrap` or `oidc` and names
-bootstrap packages in the GitHub prerelease. If the version does not exist, the
+bootstrap packages in the GitHub Release. If the version does not exist, the
 job publishes the same retained tarball with OIDC and requires provenance.
 Never rebuild it.
 
@@ -203,10 +206,12 @@ Run `pnpm changelog` to draft release notes from Conventional Commits. Review
 the generated entry before it enters the release pull request. Changelogen does
 not publish, push, tag, or own the three-package version family.
 
-The dispatch version must match the Nuxt package version, and `CHANGELOG.md`
-must contain a matching `## v<version>` section. After registry equality
-succeeds, the workflow creates the Git tag and GitHub prerelease from that
-section. The job runs no package install and no repository script.
+For `vue-nuxt`, the dispatch version must match the coupled root version and
+`CHANGELOG.md` must contain `## v<version>`. For `mcp`, it must match the MCP
+manifest and the heading is `## mcp-v<version>`. After registry equality
+succeeds, the workflow creates the target's Git tag and GitHub Release from
+that section. The privileged job runs no package install and no repository
+script.
 
 The release pull request is squash-merged after the hosted source certification
 is green. Public launch notes name only the final published coordinates.

--- a/scripts/check-security-governance.mjs
+++ b/scripts/check-security-governance.mjs
@@ -18,7 +18,7 @@ export function validateSecurityGovernance(input) {
   const commitAuthor = normalizedName(input?.commitAuthor)
 
   if (governanceMode !== 'solo-maintainer') {
-    failures.push('BCN_GOVERNANCE_MODE must be solo-maintainer for this prerelease')
+    failures.push('BCN_GOVERNANCE_MODE must be solo-maintainer for this release')
   }
   if (!releaseOwner) failures.push('RELEASE_OWNER must identify the release actor')
   if (/(?:\[bot\]|github-actions)$/iu.test(releaseOwner)) {
@@ -29,24 +29,25 @@ export function validateSecurityGovernance(input) {
   return failures
 }
 
-export function validatePrereleaseIdentity(releaseTag, packageVersion) {
+export function validateReleaseIdentity(releaseTag, packageVersion, releaseTarget) {
+  const prefix = releaseTarget === 'mcp' ? 'mcp-v' : releaseTarget === 'vue-nuxt' ? 'v' : undefined
   if (
+    !prefix ||
     typeof releaseTag !== 'string' ||
     typeof packageVersion !== 'string' ||
-    releaseTag !== `v${packageVersion}` ||
-    !packageVersion.includes('-')
+    releaseTag !== `${prefix}${packageVersion}`
   ) {
-    return ['tag must exactly match a prerelease package version']
+    return ['tag must exactly match the selected release target version']
   }
   return []
 }
 
 function parseArguments(arguments_) {
-  const prerelease = arguments_.includes('--prerelease')
-  const unknown = arguments_.filter((argument) => argument !== '--prerelease')
+  const release = arguments_.includes('--release')
+  const unknown = arguments_.filter((argument) => argument !== '--release')
   if (unknown.length > 0) throw new Error(`unknown governance-check option: ${unknown[0]}`)
-  if (!prerelease) throw new Error('the governance check is only defined for --prerelease')
-  return { prerelease }
+  if (!release) throw new Error('the governance check is only defined for --release')
+  return { release }
 }
 
 function run() {
@@ -61,8 +62,16 @@ function run() {
     releaseOwner: process.env.RELEASE_OWNER,
   }
   const failures = validateSecurityGovernance(governance)
-  const packageJson = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'))
-  failures.push(...validatePrereleaseIdentity(process.env.RELEASE_TAG, packageJson.version))
+  const manifest =
+    process.env.RELEASE_TARGET === 'mcp' ? 'packages/mcp/package.json' : 'package.json'
+  const packageJson = JSON.parse(readFileSync(resolve(repoRoot, manifest), 'utf8'))
+  failures.push(
+    ...validateReleaseIdentity(
+      process.env.RELEASE_TAG,
+      packageJson.version,
+      process.env.RELEASE_TARGET,
+    ),
+  )
 
   if (failures.length > 0) {
     console.error(`Security governance check failed with ${failures.length} issue(s):`)
@@ -79,7 +88,7 @@ function run() {
       sourceCommit: process.env.GITHUB_SHA ?? null,
     }),
   )
-  console.log('Solo-maintainer prerelease governance check passed.')
+  console.log('Solo-maintainer release governance check passed.')
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) run()

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -1,0 +1,59 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  getPackageArtifactCoordinates,
+  validatePackageArtifactVersion,
+} from './package-artifact-coordinates.mjs'
+import { requirePreparedReleaseNotes } from './release-changelog.mjs'
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
+
+export function releaseChannelForVersion(version) {
+  return validatePackageArtifactVersion(version).includes('-') ? 'next' : 'latest'
+}
+
+export function releaseCoordinates(target, workspaceVersion, mcpVersion) {
+  if (target === 'vue-nuxt') {
+    const version = validatePackageArtifactVersion(workspaceVersion)
+    return { tag: `v${version}`, version }
+  }
+  if (target === 'mcp') {
+    const version = validatePackageArtifactVersion(mcpVersion)
+    return { tag: `mcp-v${version}`, version }
+  }
+  throw new Error('Release target must be vue-nuxt or mcp.')
+}
+
+function writeMcpMetadata() {
+  const coordinates = getPackageArtifactCoordinates('mcp', { repositoryRoot: root })
+  const evidence = JSON.parse(readFileSync(coordinates.paths.evidence, 'utf8'))
+  const workspace = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+  const mcp = JSON.parse(readFileSync(join(root, 'packages/mcp/package.json'), 'utf8'))
+  const release = releaseCoordinates('mcp', workspace.version, mcp.version)
+  writeFileSync(
+    join(dirname(coordinates.paths.evidence), 'mcp-release.json'),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        sourceSha: evidence.sourceCommit,
+        tag: release.tag,
+        version: release.version,
+        notes: requirePreparedReleaseNotes(
+          readFileSync(join(root, 'CHANGELOG.md'), 'utf8'),
+          release.tag,
+        ),
+      },
+      null,
+      2,
+    )}\n`,
+  )
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (process.argv[2] !== 'write-mcp-metadata' || process.argv.length !== 3) {
+    throw new Error('Usage: release-target.mjs write-mcp-metadata')
+  }
+  writeMcpMetadata()
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -56,7 +56,14 @@ if (
   throw new Error('Workspace package.json must declare the release package manager.')
 }
 const version = artifactCoordinates.version
-const tag = getReleaseFamilyTag(workspacePackageJson.version)
+const releaseTarget = process.env.BCN_RELEASE_TARGET ?? 'vue-nuxt'
+if (!['vue-nuxt', 'mcp'].includes(releaseTarget)) throw new Error('BCN_RELEASE_TARGET is invalid.')
+const isSelectedTarget =
+  releaseTarget === 'mcp' ? releasePackageId === 'mcp' : releasePackageId !== 'mcp'
+const tag =
+  releaseTarget === 'mcp' && releasePackageId === 'mcp'
+    ? `mcp-v${version}`
+    : getReleaseFamilyTag(workspacePackageJson.version)
 const expectedArtifactFiles = artifactCoordinates.files
 
 function parseArguments(args) {
@@ -324,7 +331,7 @@ function verifyArtifact(evidenceFile) {
 function createArtifact() {
   const sourceCommit = output('git', ['rev-parse', 'HEAD'])
   if (!/^[0-9a-f]{40}$/u.test(sourceCommit)) throw new Error('Could not resolve source commit.')
-  assertReleaseTagIsUnusedOrCurrent(sourceCommit)
+  if (isSelectedTarget) assertReleaseTagIsUnusedOrCurrent(sourceCommit)
   assertPackageManifestMatchesCommit(releasePackageId, sourceCommit)
   assertPackageArtifactWriteTarget(releasePackageId)
 
@@ -427,7 +434,7 @@ function main() {
     return
   }
   ensureCleanWorkingTree()
-  requirePreparedChangelog()
+  if (isSelectedTarget) requirePreparedChangelog()
   const artifact = createArtifact()
   if (command === 'prepare') {
     run('node', [

--- a/test/release-control/package-manifest-consistency.test.ts
+++ b/test/release-control/package-manifest-consistency.test.ts
@@ -173,7 +173,9 @@ describe('contributor intake consistency', () => {
     const bootstrap = releasing.slice(bootstrapStart, bootstrapEnd)
     const afterBootstrap = releasing.slice(bootstrapEnd)
     expect(bootstrap).toContain('npm therefore rejects its trusted-publisher configuration')
-    expect(bootstrap).toContain('--access public --tag next --ignore-scripts')
+    expect(bootstrap).toMatch(/--access\s+public --tag <channel> --ignore-scripts/u)
+    expect(bootstrap).toContain('`latest` for')
+    expect(bootstrap).toContain('`next` for a prerelease')
     expect(bootstrap).toContain('two-factor authentication for')
     expect(bootstrap).toContain('authorization and writes')
     expect(bootstrap).toContain('Do not use an access token that bypasses two-factor')
@@ -181,7 +183,7 @@ describe('contributor intake consistency', () => {
     expect(afterBootstrap).not.toMatch(
       /(?:workstation|owning human).{0,120}(?:publish|tag|release)/su,
     )
-    expect(afterBootstrap).not.toContain('--access public --tag next --ignore-scripts')
+    expect(afterBootstrap).not.toMatch(/--access\s+public --tag <channel> --ignore-scripts/u)
     expect(releasing).toMatch(/Later versions have no workstation\s+publication path\./u)
   })
 })

--- a/test/release-control/release-bootstrap-policy.test.ts
+++ b/test/release-control/release-bootstrap-policy.test.ts
@@ -38,21 +38,37 @@ interface PackageState {
 
 describe('first-package publication recovery', () => {
   it('publishes every missing package with OIDC and reports each result', () => {
-    runScenario('missing packages use OIDC', {
+    runScenario('missing Vue/Nuxt packages use OIDC', {
       states: Object.fromEntries(packages.map(([, name]) => [name, { existing: false }])),
-      expectedModes: { mcp: 'oidc', nuxt: 'oidc', vue: 'oidc' },
-      expectedPublishes: 3,
+      expectedModes: { nuxt: 'oidc', vue: 'oidc' },
+      expectedPublishes: 2,
+    })
+    runScenario('missing MCP package uses OIDC', {
+      expectedModes: { mcp: 'oidc' },
+      expectedPublishes: 1,
+      states: { '@lupinum/better-convex-mcp': { existing: false } },
+      target: 'mcp',
     })
   }, 30_000)
 
   it('accepts matching first-version bootstrap bytes only when explicitly authorized', () => {
     runScenario('matching bootstrap set', {
-      bootstrapPackages: packages.map(([, name]) => name).join(','),
+      bootstrapPackages: packages
+        .slice(0, 2)
+        .map(([, name]) => name)
+        .join(','),
       states: Object.fromEntries(
         packages.map(([, name]) => [name, { attested: false, existing: true }]),
       ),
-      expectedModes: { mcp: 'bootstrap', nuxt: 'bootstrap', vue: 'bootstrap' },
+      expectedModes: { nuxt: 'bootstrap', vue: 'bootstrap' },
       expectedPublishes: 0,
+    })
+    runScenario('matching MCP bootstrap', {
+      bootstrapPackages: '@lupinum/better-convex-mcp',
+      expectedModes: { mcp: 'bootstrap' },
+      expectedPublishes: 0,
+      states: { '@lupinum/better-convex-mcp': { attested: false, existing: true } },
+      target: 'mcp',
     })
   }, 30_000)
 
@@ -62,10 +78,9 @@ describe('first-package publication recovery', () => {
       states: {
         '@lupinum/better-convex-vue': { attested: true, existing: true },
         '@lupinum/better-convex-nuxt': { attested: false, existing: true },
-        '@lupinum/better-convex-mcp': { existing: false },
       },
-      expectedModes: { mcp: 'oidc', nuxt: 'bootstrap', vue: 'oidc' },
-      expectedPublishes: 1,
+      expectedModes: { nuxt: 'bootstrap', vue: 'oidc' },
+      expectedPublishes: 0,
     })
   }, 30_000)
 
@@ -140,7 +155,7 @@ describe('first-package publication recovery', () => {
       pollDelayMs: '5000',
     })
     runScenario('one immediate retry is valid', {
-      expectedModes: { mcp: 'oidc', nuxt: 'oidc', vue: 'oidc' },
+      expectedModes: { nuxt: 'oidc', vue: 'oidc' },
       expectedPublishes: 0,
       pollAttempts: '1',
       pollDelayMs: '0',
@@ -164,6 +179,7 @@ function runScenario(
     expectedPublishes?: number
     pollAttempts?: string
     pollDelayMs?: string
+    target?: 'mcp' | 'vue-nuxt'
     states?: Record<
       string,
       {
@@ -187,7 +203,11 @@ function runScenario(
     const artifacts = join(root, '.release-artifacts')
     mkdirSync(bin)
     const packageStates: Record<string, PackageState> = {}
-    for (const [lane, packageName, version] of packages) {
+    const target = options.target ?? 'vue-nuxt'
+    const targetPackages = packages.filter(([lane]) =>
+      target === 'mcp' ? lane === 'mcp' : lane !== 'mcp',
+    )
+    for (const [lane, packageName, version] of targetPackages) {
       const directory = join(artifacts, lane, version)
       mkdirSync(directory, { recursive: true })
       const tarball = `${lane}.tgz`
@@ -254,6 +274,7 @@ function runScenario(
         GITHUB_SHA: 'a'.repeat(40),
         GITHUB_STEP_SUMMARY: join(root, 'summary.md'),
         RELEASE_VERSION: '1.0.0-beta.1',
+        RELEASE_TARGET: target,
         REGISTRY_POLL_ATTEMPTS: options.pollAttempts ?? '5',
         REGISTRY_POLL_DELAY_MS: options.pollDelayMs ?? '0',
       },

--- a/test/release-control/release-target.test.ts
+++ b/test/release-control/release-target.test.ts
@@ -18,4 +18,11 @@ describe('release target policy', () => {
       version: '2.0.0',
     })
   })
+
+  it('rejects malformed versions and unknown targets', () => {
+    expect(() => releaseCoordinates('vue-nuxt', 'not-a-version', '2.0.0')).toThrow()
+    expect(() => releaseCoordinates('other', '1.0.0', '2.0.0')).toThrow(
+      'Release target must be vue-nuxt or mcp.',
+    )
+  })
 })

--- a/test/release-control/release-target.test.ts
+++ b/test/release-control/release-target.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { releaseChannelForVersion, releaseCoordinates } from '../../scripts/release-target.mjs'
+
+describe('release target policy', () => {
+  it('derives stable and prerelease channels from each package version', () => {
+    expect(releaseChannelForVersion('1.0.0')).toBe('latest')
+    expect(releaseChannelForVersion('1.1.0-beta.1')).toBe('next')
+  })
+
+  it('keeps the coupled Vue/Nuxt and independent MCP tag spaces separate', () => {
+    expect(releaseCoordinates('vue-nuxt', '1.0.0', '2.0.0')).toEqual({
+      tag: 'v1.0.0',
+      version: '1.0.0',
+    })
+    expect(releaseCoordinates('mcp', '1.0.0', '2.0.0')).toEqual({
+      tag: 'mcp-v2.0.0',
+      version: '2.0.0',
+    })
+  })
+})

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -623,6 +623,9 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     expect(publishRuns).toHaveLength(1)
     expect(publishRuns[0]).toContain("version.includes('-') ? 'next' : 'latest'")
     expect(publishRuns[0]).toContain('const channelName = releaseChannel(candidate.version)')
+    expect(publishRuns[0]).toContain("process.env.RELEASE_TARGET === 'mcp'")
+    expect(publishRuns[0]).toContain("packageOrder.filter(([id]) => id === 'mcp')")
+    expect(publishRuns[0]).toContain("packageOrder.filter(([id]) => id !== 'mcp')")
     expect(publishRuns[0]).toContain("'--ignore-scripts', '--provenance'")
     for (const { job } of oidcJobs) {
       expect(
@@ -684,6 +687,8 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     expect(githubReleaseRuns).toContain('vue-nuxt-artifact-set.json')
     expect(githubReleaseRuns).toContain("-name 'release.json'")
     expect(githubReleaseRuns).toContain("-name 'mcp-release.json'")
+    expect(githubReleaseRuns).toContain('test "${#tarballs[@]}" -eq 1')
+    expect(githubReleaseRuns).toContain('test "${#tarballs[@]}" -eq 2')
     expect(githubReleaseRuns).toContain('"$RUNNER_TEMP/release.json"')
     expect(githubReleaseRuns).toContain('mcp_evidence=".release-artifacts/artifact.json"')
     expect(githubReleaseRuns).toContain('test -f "$mcp_evidence"')

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -582,7 +582,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     }
   })
 
-  it('publishes the complete set through one protected OIDC job under next', () => {
+  it('publishes the complete set through one protected OIDC job on derived channels', () => {
     expect(workflow.on).toEqual({
       workflow_dispatch: {
         inputs: {
@@ -594,9 +594,16 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
             type: 'string',
           },
           version: {
-            description: 'Exact Nuxt and Vue prerelease version',
+            description: 'Exact version of the selected release target',
             required: true,
             type: 'string',
+          },
+          target: {
+            description: 'Coupled Vue/Nuxt set or independently versioned MCP package',
+            required: true,
+            default: 'vue-nuxt',
+            type: 'choice',
+            options: ['vue-nuxt', 'mcp'],
           },
         },
       },
@@ -606,7 +613,7 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
       .map(([jobId, job]) => ({ jobId, job }))
     expect(oidcJobs.map(({ jobId }) => jobId)).toEqual(['publish-packages'])
     expect(oidcJobs.every(({ job }) => job.environment === 'npm')).toBe(true)
-    expect(workflow.env?.BCN_RELEASE_DIST_TAG).toBe('next')
+    expect(workflow.env?.BCN_RELEASE_DIST_TAG).toBeUndefined()
 
     const publishRuns = oidcJobs.flatMap(({ job }) =>
       (job.steps ?? [])
@@ -614,7 +621,8 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
         .filter((run): run is string => run?.includes("'publish', candidate.tarball") ?? false),
     )
     expect(publishRuns).toHaveLength(1)
-    expect(publishRuns[0]).toContain('process.env.BCN_RELEASE_DIST_TAG')
+    expect(publishRuns[0]).toContain("version.includes('-') ? 'next' : 'latest'")
+    expect(publishRuns[0]).toContain('const channelName = releaseChannel(candidate.version)')
     expect(publishRuns[0]).toContain("'--ignore-scripts', '--provenance'")
     for (const { job } of oidcJobs) {
       expect(
@@ -675,11 +683,13 @@ if (args[0] === 'scripts/release.mjs' && args[1] === 'artifact') {
     expect(githubReleaseRuns).toContain('release_assets')
     expect(githubReleaseRuns).toContain('vue-nuxt-artifact-set.json')
     expect(githubReleaseRuns).toContain("-name 'release.json'")
+    expect(githubReleaseRuns).toContain("-name 'mcp-release.json'")
     expect(githubReleaseRuns).toContain('"$RUNNER_TEMP/release.json"')
     expect(githubReleaseRuns).toContain('mcp_evidence=".release-artifacts/artifact.json"')
     expect(githubReleaseRuns).toContain('test -f "$mcp_evidence"')
     expect(githubReleaseRuns).toContain('git/ref/tags/$TAG')
     expect(githubReleaseRuns).toContain('test "$tag_sha" = "$GITHUB_SHA"')
+    expect(githubReleaseRuns).toContain('edit_flags=(--prerelease=false)')
     expect(githubReleaseRuns).toContain(
       'This first npm version was created from the exact CI-certified artifact',
     )

--- a/test/unit/security-governance.test.ts
+++ b/test/unit/security-governance.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
 import {
-  validatePrereleaseIdentity,
+  validateReleaseIdentity,
   validateSecurityGovernance,
 } from '../../scripts/check-security-governance.mjs'
 
@@ -28,7 +28,7 @@ describe('security governance gate', () => {
         ...validInput,
         governanceMode: 'committee',
       }),
-    ).toEqual(['BCN_GOVERNANCE_MODE must be solo-maintainer for this prerelease'])
+    ).toEqual(['BCN_GOVERNANCE_MODE must be solo-maintainer for this release'])
     expect(
       validateSecurityGovernance({
         ...validInput,
@@ -43,10 +43,11 @@ describe('security governance gate', () => {
     ])
   })
 
-  it('keeps prerelease release identity validation in the direct workflow script', () => {
-    expect(validatePrereleaseIdentity('v0.7.0-beta.0', '0.7.0-beta.0')).toEqual([])
-    expect(validatePrereleaseIdentity('v0.7.0', '0.7.0')).not.toEqual([])
-    expect(validatePrereleaseIdentity('v0.7.0-beta.1', '0.7.0-beta.0')).not.toEqual([])
+  it('validates stable and prerelease identities for each release target', () => {
+    expect(validateReleaseIdentity('v0.7.0-beta.0', '0.7.0-beta.0', 'vue-nuxt')).toEqual([])
+    expect(validateReleaseIdentity('v0.7.0', '0.7.0', 'vue-nuxt')).toEqual([])
+    expect(validateReleaseIdentity('mcp-v1.0.0', '1.0.0', 'mcp')).toEqual([])
+    expect(validateReleaseIdentity('v1.0.0', '1.0.0', 'mcp')).not.toEqual([])
   })
 
   it('runs only in the prerelease workflow with GitHub-owned release identity', () => {
@@ -57,11 +58,13 @@ describe('security governance gate', () => {
     }
     const gate = Object.values(prerelease.jobs ?? {})
       .flatMap((job) => job.steps ?? [])
-      .find((step) => step.run === 'pnpm check:security-governance --prerelease')
+      .find((step) => step.run === 'pnpm check:security-governance --release')
     expect(gate?.env).toEqual({
       BCN_GOVERNANCE_MODE: 'solo-maintainer',
       RELEASE_OWNER: '${{ github.actor }}',
-      RELEASE_TAG: 'v${{ inputs.version }}',
+      RELEASE_TAG:
+        "${{ inputs.target == 'mcp' && format('mcp-v{0}', inputs.version) || format('v{0}', inputs.version) }}",
+      RELEASE_TARGET: '${{ inputs.target }}',
     })
 
     const scheduled = readFileSync(resolve(root, '.github/workflows/security-extended.yml'), 'utf8')


### PR DESCRIPTION
Better Convex’s trusted workflow accepted prereleases only and forced every package onto `next`. MCP also shared the Vue/Nuxt Git tag coordinate, so it could not move independently.

The existing trusted-publisher workflow now derives `latest` or `next` from each exact package version. Vue and Nuxt remain coupled under `v*`; MCP uses its own `mcp-v*` coordinate. The protected job still publishes only retained artifacts through the `npm` environment with OIDC and provenance.

Closes #95.

## Verification

- `pnpm check` — 183 files and 2,113 tests passed
- focused release workflow, release-target, and governance tests

## Release note

- Stable package versions use `latest`; prereleases use `next`.
- Vue/Nuxt releases process only the coupled set. MCP releases process only MCP.

## Risk and compatibility

The publishing workflow is security-sensitive. The protected job still has no checkout or dependency install and publishes only retained target artifacts. The workflow filename, npm trusted-publisher identity, package APIs, and package versions do not change.
