### PR TITLE
fix(devtools): isolate identical query controllers

### DIFF
--- a/src/runtime/composables/useConvexQuery.ts
+++ b/src/runtime/composables/useConvexQuery.ts
@@ -204,26 +204,34 @@ function createClientConvexQueryState<
   const status = computed<ConvexCallStatus>(() =>
     error.value ? 'error' : (result.status.value as ConvexCallStatus),
   )
+  const devtoolsSink = runtime?.getDevtoolsSink()
+  const devtoolsQueryId = devtoolsSink?.registerQuery({
+    logicalKey: hydrationKey,
+    name: getFunctionName(query),
+    args: currentBoundary.value.args,
+    status: status.value,
+    data: result.data.value,
+    error: error.value?.message,
+    options: { immediate, lazy, server, subscribe: true, auth },
+  })
   const stopDevtools = watch(
-    [status, result.data, error],
-    ([currentStatus, data, currentError]) => {
-      runtime?.getDevtoolsSink()?.upsertQuery({
-        id: hydrationKey,
-        name: getFunctionName(query),
-        args: currentBoundary.value.args,
+    [currentBoundary, status, result.data, error],
+    ([boundary, currentStatus, data, currentError]) => {
+      if (!devtoolsSink || !devtoolsQueryId) return
+      devtoolsSink.updateQuery(devtoolsQueryId, {
+        logicalKey: boundary.key,
+        args: boundary.args,
         status: currentStatus,
         data,
         error: currentError?.message,
-        options: { immediate, lazy, server, subscribe: true, auth },
       })
     },
-    { immediate: true },
   )
   onScopeDispose(() => {
     stopHydrationBoundaryRetirement()
     stopHydratedErrorReconciliation()
     stopDevtools()
-    runtime?.getDevtoolsSink()?.removeQuery(hydrationKey)
+    if (devtoolsQueryId) devtoolsSink?.removeQuery(devtoolsQueryId)
   })
   return {
     resultData: Object.freeze({

--- a/src/runtime/devtools/sink.ts
+++ b/src/runtime/devtools/sink.ts
@@ -10,7 +10,13 @@ type MutationSubscriber = (entries: MutationEntry[]) => void
 export interface DevtoolsSink {
   getQueries(): QueryRegistryEntry[]
   getQuery(id: string): QueryRegistryEntry | undefined
-  upsertQuery(entry: Omit<QueryRegistryEntry, 'lastUpdated'>): void
+  registerQuery(entry: Omit<QueryRegistryEntry, 'id' | 'lastUpdated'>): string
+  updateQuery(
+    id: string,
+    update: Partial<
+      Pick<QueryRegistryEntry, 'logicalKey' | 'args' | 'status' | 'data' | 'error' | 'options'>
+    >,
+  ): void
   removeQuery(id: string): void
   subscribeToQueries(callback: QuerySubscriber): () => void
   registerMutation(entry: Omit<MutationEntry, 'id'>): string
@@ -66,17 +72,40 @@ export function createDevtoolsSink(): DevtoolsSink {
       const entry = queries.get(id)
       return entry ? cloneEntry(entry) : undefined
     },
-    upsertQuery(entry) {
-      if (disposed) return
-      queries.delete(entry.id)
-      queries.set(entry.id, {
+    registerQuery(entry) {
+      if (disposed) return ''
+      const id = createId()
+      queries.set(id, {
         ...entry,
+        id,
         args: sanitizeDiagnosticValue(entry.args),
         data: sanitizeDiagnosticValue(entry.data),
         error: entry.error === undefined ? undefined : String(sanitizeDiagnosticValue(entry.error)),
         lastUpdated: Date.now(),
       })
       while (queries.size > MAX_QUERIES) queries.delete(queries.keys().next().value!)
+      notifyQueries()
+      return id
+    },
+    updateQuery(id, update) {
+      if (disposed) return
+      const existing = queries.get(id)
+      if (!existing) return
+      queries.set(id, {
+        ...existing,
+        ...update,
+        ...(Object.hasOwn(update, 'args') ? { args: sanitizeDiagnosticValue(update.args) } : {}),
+        ...(Object.hasOwn(update, 'data') ? { data: sanitizeDiagnosticValue(update.data) } : {}),
+        ...(Object.hasOwn(update, 'error')
+          ? {
+              error:
+                update.error === undefined
+                  ? undefined
+                  : String(sanitizeDiagnosticValue(update.error)),
+            }
+          : {}),
+        lastUpdated: Date.now(),
+      })
       notifyQueries()
     },
     removeQuery(id) {

--- a/src/runtime/devtools/types.ts
+++ b/src/runtime/devtools/types.ts
@@ -9,7 +9,10 @@ export type { ConvexUser } from '../utils/types'
 export type QueryStatus = 'pending' | 'success' | 'error' | 'idle'
 
 export interface QueryRegistryEntry {
+  /** Unique controller instance. Identical subscriptions still have different IDs. */
   id: string
+  /** Stable query/cache identity shared by equivalent controller instances. */
+  logicalKey: string
   name: string
   args: unknown
   status: QueryStatus

--- a/src/runtime/devtools/ui/components/QueryDetail.vue
+++ b/src/runtime/devtools/ui/components/QueryDetail.vue
@@ -152,7 +152,7 @@ const options = computed<{
 
       <div class="detail-section">
         <div class="detail-title">Cache Key</div>
-        <div class="json-viewer" style="max-height: 60px">{{ query.id }}</div>
+        <div class="json-viewer" style="max-height: 60px">{{ query.logicalKey }}</div>
       </div>
 
       <div class="detail-section">

--- a/test/unit/devtools-sink.test.ts
+++ b/test/unit/devtools-sink.test.ts
@@ -82,4 +82,40 @@ describe('createDevtoolsSink', () => {
     })
     expect(sink.getMutations()[0]!.args).not.toHaveProperty('nested.extra')
   })
+
+  it('tracks identical query controllers independently', () => {
+    const sink = createDevtoolsSink()
+    const entry = {
+      logicalKey: 'convex:query:notes:list:{}',
+      name: 'notes:list',
+      args: {},
+      status: 'pending' as const,
+      data: undefined,
+      options: {
+        auth: 'required' as const,
+        immediate: true,
+        lazy: false,
+        server: true,
+        subscribe: true,
+      },
+    }
+
+    const firstId = sink.registerQuery(entry)
+    const secondId = sink.registerQuery(entry)
+
+    expect(firstId).not.toBe(secondId)
+    expect(sink.getQueries()).toHaveLength(2)
+    expect(sink.getQueries().map(({ logicalKey }) => logicalKey)).toEqual([
+      entry.logicalKey,
+      entry.logicalKey,
+    ])
+
+    sink.updateQuery(firstId, { status: 'success', data: ['first'] })
+    expect(sink.getQuery(firstId)).toMatchObject({ status: 'success', data: ['first'] })
+    expect(sink.getQuery(secondId)).toMatchObject({ status: 'pending' })
+
+    sink.removeQuery(firstId)
+    expect(sink.getQueries()).toHaveLength(1)
+    expect(sink.getQuery(secondId)).toBeDefined()
+  })
 })


### PR DESCRIPTION
## Result

DevTools now gives identical query calls separate controller identities. One component can dispose, refresh, or resubscribe without overwriting another component's diagnostics.

## Verification

- Focused sink tests cover identical function references with independent controller lifecycles.
- The full source and packed-consumer CI lanes must pass before merge.

## Release note

Fix DevTools query diagnostics for multiple identical subscriptions.

## Risk

The change affects diagnostics only. Convex remains the subscription and cache owner; no duplicate runtime cache or global observer was added.
