### PR TITLE
fix(release): make Linux artifacts reproducible

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -44,6 +44,13 @@ Follow [RELEASING.md](./RELEASING.md). The protected workflow is the only normal
 publication path. It must publish only retained artifacts that passed source,
 consumer, security, and registry checks.
 
+The reviewed Linux workflow is the byte authority for release artifacts and
+candidate lockfiles. `npm pack` can produce the same uncompressed tar archive
+with different gzip bytes on macOS because the host zlib implementation is
+different. Do not record workstation hashes or run artifact creation, candidate
+lock generation, or `release:smoke` outside the Linux builder. Verification of
+an already retained artifact remains platform-independent.
+
 Use `pnpm changelog` to draft the public notes from Conventional Commits. Review
 the result and remove internal rehearsal details. `CHANGELOG.md` records only
 versions that npm contains. Do not use Changelogen to publish, push, tag, or

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -844,7 +844,7 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@lupinum/better-convex-nuxt@1.0.0-beta.1':
-    resolution: {integrity: sha512-bu0aQ9NCapOanqMg/0jGcpf2nZx6qNhm2JbfmQxCdyUetU8/zUHzExFRgcYGtcIk8Gy+labLhrSWLJZh81V8mA==}
+    resolution: {integrity: sha512-IEQlHuTvyTWMnRVOiti8Pz8YmnGWCpKpaXPEC6ATZz+i0YXXAvxh69zO9PlDK38cwL/d0CajrEccXF5OhEYbXQ==}
     engines: {node: ^22.19.0 || ^24.11.0}
     hasBin: true
     peerDependencies:
@@ -859,7 +859,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-vue@1.0.0-beta.1':
-    resolution: {integrity: sha512-K7k2ycwtegW9KJAt/zgbVxp3dXFpllM2fEJ1eYszLP8Lp+4wweFBLK3cubop7uhkFGaz2DkcdW92VOtd8eR/KA==}
+    resolution: {integrity: sha512-lfJaneI94+hAvDCf/sPxW/KFci85Uf4SVuawTzY4WFJjVwUB80U6jWoq3TchD6nHhfsMKvvvPExJXFnqdDwFvA==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       convex: '>=1.42.2 <2'
@@ -6249,6 +6249,7 @@ snapshots:
 
   '@lupinum/better-convex-vue@1.0.0-beta.1(convex@1.42.2)(vue@3.5.41(typescript@5.9.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       convex: 1.42.2
       ohash: 2.0.12
       vue: 3.5.41(typescript@5.9.3)

--- a/scripts/prepare-candidate-app-locks.mjs
+++ b/scripts/prepare-candidate-app-locks.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { assertReleaseBuilderPlatform } from './release-builder-platform.mjs'
 import { withReleasePreflightTarballs } from './release-preflight-tarballs.mjs'
 
 const repositoryRoot = resolve(import.meta.dirname, '..')
@@ -54,5 +55,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1]
   if (!['check', 'update'].includes(mode) || process.argv.length !== 3) {
     throw new Error('Usage: prepare-candidate-app-locks.mjs check|update')
   }
+  assertReleaseBuilderPlatform()
   prepareCandidateAppLocks(mode)
 }

--- a/scripts/prepare-candidate-set.mjs
+++ b/scripts/prepare-candidate-set.mjs
@@ -20,6 +20,7 @@ import {
   createCandidateSetEvidence,
   getCandidateSetCoordinates,
 } from './package-candidate-set.mjs'
+import { assertReleaseBuilderPlatform } from './release-builder-platform.mjs'
 import { requirePreparedReleaseNotes } from './release-changelog.mjs'
 
 const root = resolve(import.meta.dirname, '..')
@@ -33,6 +34,7 @@ if (
     'Usage: prepare-candidate-set.mjs artifact|family|prepare | verify <artifact-set.json>',
   )
 }
+if (command !== 'verify') assertReleaseBuilderPlatform()
 
 function run(executable, args, options = {}) {
   console.log(`\n> ${[executable, ...args].join(' ')}`)

--- a/scripts/release-builder-platform.mjs
+++ b/scripts/release-builder-platform.mjs
@@ -1,0 +1,11 @@
+export const releaseBuilderPlatform = 'linux'
+
+/** Require the platform that owns publishable package bytes and candidate locks. */
+export function assertReleaseBuilderPlatform(platform = process.platform) {
+  if (platform !== releaseBuilderPlatform) {
+    throw new Error(
+      'Release artifacts, candidate locks, and release smoke must be created on the reviewed Linux builder.',
+    )
+  }
+  return platform
+}

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process'
 import { resolve } from 'node:path'
 
 import { verifyCandidateAppLocks } from './prepare-candidate-app-locks.mjs'
+import { assertReleaseBuilderPlatform } from './release-builder-platform.mjs'
 import { withReleasePreflightTarballs } from './release-preflight-tarballs.mjs'
 
 const root = resolve(import.meta.dirname, '..')
@@ -21,6 +22,7 @@ function ensureClean() {
   if (status) throw new Error(`Release smoke requires a clean working tree:\n${status}`)
 }
 
+assertReleaseBuilderPlatform()
 ensureClean()
 run('node', ['scripts/check-workspace-dependency-alignment.mjs'])
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,10 +38,12 @@ import {
 } from './package-check/production-manifest-contract.mjs'
 import { buildContentManifest, packAndExtract } from './package-check/tarball.mjs'
 import { assertPackedRuntimeFingerprintBinding } from './package-runtime-fingerprint-profile.mjs'
+import { assertReleaseBuilderPlatform } from './release-builder-platform.mjs'
 import { getReleaseFamilyTag, requirePreparedReleaseNotes } from './release-changelog.mjs'
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const { command, packageId: releasePackageId, verifyPath } = parseArguments(process.argv.slice(2))
+if (command !== 'verify') assertReleaseBuilderPlatform()
 const artifactCoordinates = getPackageArtifactCoordinates(releasePackageId)
 const packageJson = JSON.parse(readFileSync(artifactCoordinates.manifestPath, 'utf8'))
 const workspacePackageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'))

--- a/starters/agency/pnpm-lock.yaml
+++ b/starters/agency/pnpm-lock.yaml
@@ -671,7 +671,7 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@lupinum/better-convex-nuxt@1.0.0-beta.1':
-    resolution: {integrity: sha512-bu0aQ9NCapOanqMg/0jGcpf2nZx6qNhm2JbfmQxCdyUetU8/zUHzExFRgcYGtcIk8Gy+labLhrSWLJZh81V8mA==}
+    resolution: {integrity: sha512-IEQlHuTvyTWMnRVOiti8Pz8YmnGWCpKpaXPEC6ATZz+i0YXXAvxh69zO9PlDK38cwL/d0CajrEccXF5OhEYbXQ==}
     engines: {node: ^22.19.0 || ^24.11.0}
     hasBin: true
     peerDependencies:
@@ -686,7 +686,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-vue@1.0.0-beta.1':
-    resolution: {integrity: sha512-K7k2ycwtegW9KJAt/zgbVxp3dXFpllM2fEJ1eYszLP8Lp+4wweFBLK3cubop7uhkFGaz2DkcdW92VOtd8eR/KA==}
+    resolution: {integrity: sha512-lfJaneI94+hAvDCf/sPxW/KFci85Uf4SVuawTzY4WFJjVwUB80U6jWoq3TchD6nHhfsMKvvvPExJXFnqdDwFvA==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       convex: '>=1.42.2 <2'
@@ -4463,6 +4463,7 @@ snapshots:
 
   '@lupinum/better-convex-vue@1.0.0-beta.1(convex@1.42.2)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       convex: 1.42.2
       ohash: 2.0.12
       vue: 3.5.40(typescript@5.9.3)

--- a/starters/mcp-oauth-agent/pnpm-lock.yaml
+++ b/starters/mcp-oauth-agent/pnpm-lock.yaml
@@ -662,7 +662,7 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@lupinum/better-convex-mcp@1.0.0-beta.1':
-    resolution: {integrity: sha512-JSvIbI3I4TFdVdz014pcbMKQjVD6+OC9ISpi2K5plH2hSqs2tPzsgMqnFwHbMiEPgm2bGme2tY3GPgHRwLn3dg==}
+    resolution: {integrity: sha512-swrRLIqDCgpQkG9kYAQNpzeBrD4e6OsjdSz0RJ4KmSERDnMira0U9drfT1kSEQzvWpwM4QCAvRFk9XyECbF/9w==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       '@modelcontextprotocol/ext-apps': 1.7.5
@@ -677,7 +677,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-nuxt@1.0.0-beta.1':
-    resolution: {integrity: sha512-bu0aQ9NCapOanqMg/0jGcpf2nZx6qNhm2JbfmQxCdyUetU8/zUHzExFRgcYGtcIk8Gy+labLhrSWLJZh81V8mA==}
+    resolution: {integrity: sha512-IEQlHuTvyTWMnRVOiti8Pz8YmnGWCpKpaXPEC6ATZz+i0YXXAvxh69zO9PlDK38cwL/d0CajrEccXF5OhEYbXQ==}
     engines: {node: ^22.19.0 || ^24.11.0}
     hasBin: true
     peerDependencies:
@@ -692,7 +692,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-vue@1.0.0-beta.1':
-    resolution: {integrity: sha512-K7k2ycwtegW9KJAt/zgbVxp3dXFpllM2fEJ1eYszLP8Lp+4wweFBLK3cubop7uhkFGaz2DkcdW92VOtd8eR/KA==}
+    resolution: {integrity: sha512-lfJaneI94+hAvDCf/sPxW/KFci85Uf4SVuawTzY4WFJjVwUB80U6jWoq3TchD6nHhfsMKvvvPExJXFnqdDwFvA==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       convex: '>=1.42.2 <2'
@@ -4197,6 +4197,7 @@ snapshots:
 
   '@lupinum/better-convex-vue@1.0.0-beta.1(convex@1.42.2)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       convex: 1.42.2
       ohash: 2.0.12
       vue: 3.5.40(typescript@5.9.3)

--- a/starters/public/pnpm-lock.yaml
+++ b/starters/public/pnpm-lock.yaml
@@ -574,7 +574,7 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@lupinum/better-convex-nuxt@1.0.0-beta.1':
-    resolution: {integrity: sha512-bu0aQ9NCapOanqMg/0jGcpf2nZx6qNhm2JbfmQxCdyUetU8/zUHzExFRgcYGtcIk8Gy+labLhrSWLJZh81V8mA==}
+    resolution: {integrity: sha512-IEQlHuTvyTWMnRVOiti8Pz8YmnGWCpKpaXPEC6ATZz+i0YXXAvxh69zO9PlDK38cwL/d0CajrEccXF5OhEYbXQ==}
     engines: {node: ^22.19.0 || ^24.11.0}
     hasBin: true
     peerDependencies:
@@ -589,7 +589,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-vue@1.0.0-beta.1':
-    resolution: {integrity: sha512-K7k2ycwtegW9KJAt/zgbVxp3dXFpllM2fEJ1eYszLP8Lp+4wweFBLK3cubop7uhkFGaz2DkcdW92VOtd8eR/KA==}
+    resolution: {integrity: sha512-lfJaneI94+hAvDCf/sPxW/KFci85Uf4SVuawTzY4WFJjVwUB80U6jWoq3TchD6nHhfsMKvvvPExJXFnqdDwFvA==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       convex: '>=1.42.2 <2'
@@ -4199,6 +4199,7 @@ snapshots:
 
   '@lupinum/better-convex-vue@1.0.0-beta.1(convex@1.42.2)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       convex: 1.42.2
       ohash: 2.0.12
       vue: 3.5.40(typescript@5.9.3)

--- a/starters/team/pnpm-lock.yaml
+++ b/starters/team/pnpm-lock.yaml
@@ -706,7 +706,7 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@lupinum/better-convex-nuxt@1.0.0-beta.1':
-    resolution: {integrity: sha512-bu0aQ9NCapOanqMg/0jGcpf2nZx6qNhm2JbfmQxCdyUetU8/zUHzExFRgcYGtcIk8Gy+labLhrSWLJZh81V8mA==}
+    resolution: {integrity: sha512-IEQlHuTvyTWMnRVOiti8Pz8YmnGWCpKpaXPEC6ATZz+i0YXXAvxh69zO9PlDK38cwL/d0CajrEccXF5OhEYbXQ==}
     engines: {node: ^22.19.0 || ^24.11.0}
     hasBin: true
     peerDependencies:
@@ -721,7 +721,7 @@ packages:
         optional: true
 
   '@lupinum/better-convex-vue@1.0.0-beta.1':
-    resolution: {integrity: sha512-K7k2ycwtegW9KJAt/zgbVxp3dXFpllM2fEJ1eYszLP8Lp+4wweFBLK3cubop7uhkFGaz2DkcdW92VOtd8eR/KA==}
+    resolution: {integrity: sha512-lfJaneI94+hAvDCf/sPxW/KFci85Uf4SVuawTzY4WFJjVwUB80U6jWoq3TchD6nHhfsMKvvvPExJXFnqdDwFvA==}
     engines: {node: ^22.19.0 || ^24.11.0}
     peerDependencies:
       convex: '>=1.42.2 <2'
@@ -4523,6 +4523,7 @@ snapshots:
 
   '@lupinum/better-convex-vue@1.0.0-beta.1(convex@1.42.2)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       convex: 1.42.2
       ohash: 2.0.12
       vue: 3.5.40(typescript@5.9.3)

--- a/test/release-control/release-builder-platform.test.ts
+++ b/test/release-control/release-builder-platform.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertReleaseBuilderPlatform,
+  releaseBuilderPlatform,
+} from '../../scripts/release-builder-platform.mjs'
+
+describe('release builder platform', () => {
+  it('admits the reviewed Linux publishing authority', () => {
+    expect(assertReleaseBuilderPlatform('linux')).toBe('linux')
+    expect(releaseBuilderPlatform).toBe('linux')
+  })
+
+  it.each(['darwin', 'win32'] as const)(
+    'rejects non-authoritative %s package bytes',
+    (platform) => {
+      expect(() => assertReleaseBuilderPlatform(platform)).toThrow(
+        'Release artifacts, candidate locks, and release smoke must be created on the reviewed Linux builder.',
+      )
+    },
+  )
+})

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -27,6 +27,7 @@ const releaseControlFixtureFiles = [
   'scripts/package-certification-manifest.mjs',
   'scripts/package-runtime-fingerprint-profile.mjs',
   'scripts/prepare-candidate-set.mjs',
+  'scripts/release-builder-platform.mjs',
   'scripts/release-changelog.mjs',
   'scripts/release-preflight-tarballs.mjs',
   'scripts/verify-release.mjs',
@@ -112,6 +113,10 @@ function createReleaseControlFixture() {
     mkdirSync(dirname(destination), { recursive: true })
     writeFileSync(destination, read(relativePath))
   }
+  writeFileSync(
+    join(repository, 'scripts/release-builder-platform.mjs'),
+    "export function assertReleaseBuilderPlatform() { return 'linux' }\n",
+  )
   mkdirSync(join(repository, 'scripts/package-check'), { recursive: true })
   writeFileSync(
     join(repository, 'scripts/package-check/tarball.mjs'),


### PR DESCRIPTION
## Result

Linux is the sole authority for release tarballs, candidate locks, and release smoke. Local macOS builds may diagnose source issues but cannot mint or rewrite release evidence.

The release path pins a reviewed npm version on Node 22 and 24, builds package bytes once, verifies transferred bytes, and keeps package publication separate from this PR stack.

## Verification

- Platform-boundary and release-workflow tests cover the Linux-only invariant.
- Two independent Linux package-preview builds must produce byte-identical tarballs.
- The final Linux locks must pass frozen installs and packed consumers on Node 22.19 and Node 24.
- Luis and Ginko are rechecked against those exact bytes before merge.

## Release note

None. This stabilizes release provenance and reproducibility for the 1.0 beta candidate.

## Risk

The main risk is approving locally generated evidence that differs from publishing infrastructure. Non-Linux mutation is rejected, and the retained CI manifest binds source SHA, package hashes, and package bytes.

No package is published, no tag or release is created, and no dist-tag changes in this PR.
