### PR TITLE
fix(release): make reconciliation converge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,8 @@ jobs:
       - name: Derive the unique incomplete release intent
         id: intent
         run: node scripts/release-intent.mjs --github-output "$GITHUB_OUTPUT" --summary "$GITHUB_STEP_SUMMARY"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Verify reviewed release ownership and identity
         if: steps.intent.outputs.ready == 'true'
         run: pnpm check:security-governance --release

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       action: ${{ steps.state.outputs.action }}
       channel: ${{ steps.state.outputs.channel }}
+      first-attempt: ${{ steps.state.outputs.first-attempt }}
       sha: ${{ steps.state.outputs.sha }}
       tag: ${{ steps.state.outputs.tag }}
       unit: ${{ steps.state.outputs.unit }}
@@ -73,19 +74,22 @@ jobs:
                   { tag: `v${root.version}`, version: root.version, packages: ['@lupinum/better-convex-vue', '@lupinum/better-convex-nuxt'] },
                   { tag: `mcp-v${mcp.version}`, version: mcp.version, packages: ['@lupinum/better-convex-mcp'] },
                 ].filter(unit => changelog.split('\n').some(line => line === `## ${unit.tag}` || line.startsWith(`## ${unit.tag} `)))
-                if (units.length !== 1) continue
-                const unit = units[0]
-                let releaseIncomplete = false
-                for (const name of unit.packages) {
-                  const response = await fetch(`https://registry.npmjs.org/${name.replace('/', '%2f')}/${unit.version}`)
-                  if (response.status === 404) releaseIncomplete = true
-                  else if (!response.ok) throw new Error(`npm state for ${name}@${unit.version} is unavailable: HTTP ${response.status}.`)
+                const incompleteUnits = []
+                for (const unit of units) {
+                  let releaseIncomplete = false
+                  for (const name of unit.packages) {
+                    const response = await fetch(`https://registry.npmjs.org/${name.replace('/', '%2f')}/${unit.version}`)
+                    if (response.status === 404) releaseIncomplete = true
+                    else if (!response.ok) throw new Error(`npm state for ${name}@${unit.version} is unavailable: HTTP ${response.status}.`)
+                  }
+                  const tag = await github.rest.git.getRef({ ...context.repo, ref: `tags/${unit.tag}` }).catch(error => error.status === 404 ? null : Promise.reject(error))
+                  const release = await github.rest.repos.getReleaseByTag({ ...context.repo, tag: unit.tag }).catch(error => error.status === 404 ? null : Promise.reject(error))
+                  if (!tag || !release) releaseIncomplete = true
+                  if (releaseIncomplete) incompleteUnits.push(unit)
                 }
-                const tag = await github.rest.git.getRef({ ...context.repo, ref: `tags/${unit.tag}` }).catch(error => error.status === 404 ? null : Promise.reject(error))
-                const release = await github.rest.repos.getReleaseByTag({ ...context.repo, tag: unit.tag }).catch(error => error.status === 404 ? null : Promise.reject(error))
-                if (!tag || !release) releaseIncomplete = true
+                if (incompleteUnits.length > 1) throw new Error(`Run ${run.id} contains multiple incomplete release units (${incompleteUnits.map(unit => unit.tag).join(', ')}). Finish the earlier release first.`)
                 retained.push(run)
-                if (releaseIncomplete) incomplete.push(run)
+                if (incompleteUnits.length === 1) incomplete.push(run)
               }
               if (incomplete.length > 1) throw new Error(`Multiple incomplete retained candidates exist (${incomplete.map(run => run.id).join(', ')}). Finish the earlier release first.`)
               const selected = incomplete[0] ?? retained[0]
@@ -136,7 +140,6 @@ jobs:
         id: state
         if: steps.ci.outputs.active == 'true'
         env:
-          FIRST_ATTEMPT: ${{ github.event_name == 'workflow_run' && github.run_attempt == 1 }}
           GH_TOKEN: ${{ github.token }}
         run: node scripts/reconcile-release.mjs .release --summary "$GITHUB_STEP_SUMMARY" --github-output "$GITHUB_OUTPUT"
       - name: Verify release artifact handoff
@@ -166,6 +169,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Recheck current main immediately before first publication
+        if: needs.verify.outputs.first-attempt == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.verify.outputs.sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha > "$RUNNER_TEMP/main-sha"
+          grep -Fx "$SOURCE_SHA" "$RUNNER_TEMP/main-sha"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.11.0'
@@ -214,19 +225,68 @@ jobs:
               if (result.status !== 0) fail(`npm publish failed for ${spec}.`)
             } else if (existing !== pkg.integrity || view(pkg.name, `dist-tags.${record.channel}`) !== pkg.version || !view(spec, 'dist.attestations')) fail(`${spec} lost verified registry state.`)
           }
-          for (const pkg of record.packages) {
-            const spec = `${pkg.name}@${pkg.version}`
-            if (view(spec, 'dist.integrity') !== pkg.integrity || view(pkg.name, `dist-tags.${record.channel}`) !== pkg.version || !view(spec, 'dist.attestations')) fail(`${spec} did not expose exact bytes, channel, and provenance.`)
-          }
           NODE
 
-  github-release:
-    name: Reconcile GitHub release
+  verify-publication:
+    name: Verify published bytes and provenance
     needs: [verify, publish-packages]
     if: >-
       always() && needs.verify.result == 'success' &&
       (needs.verify.outputs.action == 'publish' || needs.verify.outputs.action == 'repair') &&
       (needs.publish-packages.result == 'success' || needs.publish-packages.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.verify.outputs.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.11.0'
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: npm install --global corepack@0.34.5 && corepack enable && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Download the verified release plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-better-convex-release
+          path: .release
+      - name: Cryptographically verify the published registry state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for delay in 0 5 10 20 40 60; do
+            sleep "$delay"
+            : > "$RUNNER_TEMP/reconcile-output"
+            if node scripts/reconcile-release.mjs .release --github-output "$RUNNER_TEMP/reconcile-output" &&
+              grep -Eq '^action=(repair|complete)$' "$RUNNER_TEMP/reconcile-output" &&
+              node --input-type=module -e "import { readFileSync } from 'node:fs'; const state = JSON.parse(readFileSync('.release/registry-verification.json', 'utf8')); if (!state.packages.every(pkg => pkg.mode === 'oidc')) process.exit(1)"; then
+              node scripts/reconcile-release.mjs .release --summary "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          done
+          echo 'npm did not expose the certified bytes, channel, and provenance before the bounded verification deadline.' >&2
+          exit 1
+      - name: Retain the provenance-verified release plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: publication-verified-better-convex-release
+          path: .release
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14
+
+  github-release:
+    name: Reconcile GitHub release
+    needs: [verify, verify-publication]
+    if: >-
+      always() && needs.verify.result == 'success' &&
+      (needs.verify.outputs.action == 'publish' || needs.verify.outputs.action == 'repair') &&
+      needs.verify-publication.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -236,7 +296,7 @@ jobs:
       - name: Download the verified release plan
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: verified-better-convex-release
+          name: publication-verified-better-convex-release
           path: .release
       - name: Create or repair the exact tag and Release
         env:
@@ -246,6 +306,8 @@ jobs:
           SOURCE_SHA: ${{ needs.verify.outputs.sha }}
         run: |
           set -euo pipefail
+          # Registry verification is derived live evidence, not a certified build asset.
+          rm -f .release/registry-verification.json
           node --input-type=module <<'NODE'
           import { spawnSync } from 'node:child_process'
           import { createHash } from 'node:crypto'
@@ -290,6 +352,11 @@ jobs:
           [ "$RELEASE_CHANNEL" = next ] && prerelease=true
           if [ "$release_exists" = true ]; then
             gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+            while IFS= read -r asset; do
+              if [ ! -f ".release/$asset" ]; then
+                gh release delete-asset "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+              fi
+            done < <(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
             gh release upload "$RELEASE_TAG" .release/* --repo "$GITHUB_REPOSITORY" --clobber
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --title "Better Convex $RELEASE_TAG" --notes-file .release/github-release-notes.md --prerelease="$prerelease"
           else
@@ -297,3 +364,41 @@ jobs:
             [ "$prerelease" = true ] && flags=(--prerelease)
             gh release create "$RELEASE_TAG" .release/* --repo "$GITHUB_REPOSITORY" --verify-tag --title "Better Convex $RELEASE_TAG" --notes-file .release/github-release-notes.md "${flags[@]}"
           fi
+
+  verify-completed-release:
+    name: Verify completed Better Convex release
+    needs: [verify, github-release]
+    if: >-
+      always() && needs.verify.result == 'success' &&
+      (needs.verify.outputs.action == 'publish' || needs.verify.outputs.action == 'repair') &&
+      needs.github-release.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.verify.outputs.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.11.0'
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: npm install --global corepack@0.34.5 && corepack enable && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Download the publication-verified release plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: publication-verified-better-convex-release
+          path: .release
+      - name: Prove the completed npm, tag, Release, metadata, and asset state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/reconcile-release.mjs .release --summary "$GITHUB_STEP_SUMMARY" --github-output "$GITHUB_OUTPUT"
+      - name: Require a complete release
+        env:
+          ACTION: ${{ steps.state.outputs.action }}
+        run: test "$ACTION" = complete

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,20 @@ fail with an instruction to finish the earlier release first.
 The trusted workflow starts from the successful CI run. Its manual dispatch has
 no inputs and exists only for missed events or reconciliation. A first
 publication attempt requires the certified SHA to remain current `main`.
-Reruns reuse the original retained candidate even after `main` advances.
+The protected job checks current `main` again immediately before that first
+publication, so an approval wait cannot make the candidate stale. Reruns reuse
+the original retained candidate even after `main` advances.
+
+After the protected job, an unprivileged verifier proves the published bytes,
+channel, Sigstore certificate identity, source SHA, and trusted workflow identity
+before GitHub history is reconciled. This verifier uses a bounded retry window
+because npm package bytes, dist-tags, and provenance can become visible at
+slightly different times after a successful publish. A final read-only verifier
+then proves the tag target, Release metadata, and every Release asset before the
+run is complete. The live `registry-verification.json` report is workflow
+evidence, not a certified build asset, so it is retained with the workflow plan
+but excluded from the public GitHub Release. This prevents pre-publication state
+from making an otherwise complete release appear to need repair forever.
 
 The source lanes are defined by `scripts/release-source-certification.mjs`:
 

--- a/scripts/candidate-app-locks.mjs
+++ b/scripts/candidate-app-locks.mjs
@@ -50,6 +50,18 @@ export function candidateAppInstallArgs(profile, frozen) {
   return args
 }
 
+/** Exempt only locally certified candidate coordinates in a temporary workspace. */
+export function withCandidateReleaseAgeExclusions(workspaceSource, artifacts) {
+  if (/^minimumReleaseAgeExclude:/mu.test(workspaceSource)) {
+    throw new Error('Candidate workspace already contains a dependency-age exception.')
+  }
+  for (const artifact of artifacts) assertArtifactIdentity(artifact)
+  const rules = artifacts
+    .map(({ packageName, version }) => `  - '${packageName}@${version}'`)
+    .join('\n')
+  return `${workspaceSource}${workspaceSource.endsWith('\n') ? '' : '\n'}minimumReleaseAgeExclude:\n${rules}\n`
+}
+
 /** Build the npm metadata served for one local release candidate. */
 export function createCandidateRegistryMetadata({
   integrity,

--- a/scripts/reconcile-release.mjs
+++ b/scripts/reconcile-release.mjs
@@ -54,12 +54,24 @@ export function assertFreshFirstAttempt({ action, firstAttempt, mainSha, sourceS
   }
 }
 
+export function isFirstPublicationAttempt(action, modes) {
+  return action === 'publish' && modes.every((mode) => mode === 'absent')
+}
+
 export function releaseMetadataState(release, record) {
   return release.name === record.title &&
     release.body?.replace(/\r\n/gu, '\n').trimEnd() === record.notes.trimEnd() &&
     release.isPrerelease === (record.channel === 'next')
     ? 'verified'
     : 'conflict'
+}
+
+export function releaseAssetFiles(record) {
+  return [
+    'github-release-notes.md',
+    'release-record.json',
+    ...record.assets.map(({ file }) => file),
+  ].sort()
 }
 
 export function evaluateProvenanceStatement(statement, pkg, integrity, sourceSha) {
@@ -165,7 +177,12 @@ function releaseState(directory, record) {
     return { release: 'absent', assets: 'absent', metadata: 'absent' }
   assert(view.status === 0, `Could not inspect ${record.tag} Release: ${view.stderr.trim()}`)
   const release = JSON.parse(view.stdout)
-  const expectedFiles = readdirSync(directory).sort()
+  const availableFiles = readdirSync(directory)
+  const expectedFiles = releaseAssetFiles(record)
+  assert(
+    expectedFiles.every((file) => availableFiles.includes(file)),
+    'The retained candidate is missing a required GitHub Release asset.',
+  )
   const observedFiles = release.assets.map((asset) => asset.name).sort()
   const metadata = releaseMetadataState(release, record)
   if (JSON.stringify(expectedFiles) !== JSON.stringify(observedFiles))
@@ -200,7 +217,7 @@ function releaseState(directory, record) {
   }
 }
 
-async function inspect(directory, record) {
+export async function inspect(directory, record) {
   assert(
     record.schemaVersion === 1 && /^[0-9a-f]{40}$/u.test(record.sourceSha),
     'Invalid release record.',
@@ -254,17 +271,21 @@ async function inspect(directory, record) {
     tag,
     ...github,
   })
-  if (action === 'publish' && process.env.FIRST_ATTEMPT === 'true') {
+  const firstAttempt = isFirstPublicationAttempt(
+    action,
+    packages.map(({ mode }) => mode),
+  )
+  if (firstAttempt) {
     const mainSha = ghJson(['api', `repos/${process.env.GITHUB_REPOSITORY}/git/ref/heads/main`])
       .object.sha
     assertFreshFirstAttempt({
       action,
-      firstAttempt: true,
+      firstAttempt,
       mainSha,
       sourceSha: record.sourceSha,
     })
   }
-  return { action, packages, tag, ...github }
+  return { action, firstAttempt, packages, tag, ...github }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
@@ -331,6 +352,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       version: record.version,
       channel: record.channel,
       tag: record.tag,
+      'first-attempt': String(state.firstAttempt),
     }))
       appendFileSync(output, `${name}=${value}\n`)
   process.stdout.write(`Release reconciliation: ${state.action}.\n`)

--- a/scripts/release-intent.mjs
+++ b/scripts/release-intent.mjs
@@ -1,7 +1,10 @@
 import { spawnSync } from 'node:child_process'
-import { appendFileSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { appendFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { inspect } from './reconcile-release.mjs'
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
 
@@ -49,12 +52,77 @@ export function classifyCandidateNeed(publications) {
   return 'partial'
 }
 
+export function classifyReleaseIntent({ publications, tag, release }) {
+  const packages = classifyCandidateNeed(publications)
+  if (![tag, release].every((state) => ['absent', 'present'].includes(state))) {
+    throw new Error('GitHub release state is unverified.')
+  }
+  if (packages !== 'reuse' && (tag === 'present' || release === 'present')) {
+    throw new Error('Public GitHub history exists before npm publication is complete.')
+  }
+  if (packages === 'reuse' && tag === 'present' && release === 'present') return 'verify'
+  return packages === 'build' ? 'build' : 'repair'
+}
+
+export function selectIncompleteIntent(states) {
+  const incomplete = states.filter(({ state }) => state !== 'complete')
+  if (incomplete.length > 1) {
+    throw new Error(
+      `Multiple incomplete release intents are active (${incomplete.map(({ intent }) => intent.tag).join(', ')}). Finish the earlier release before merging another intent.`,
+    )
+  }
+  return incomplete[0]
+}
+
 function readVersions() {
   const manifest = (path) => JSON.parse(readFileSync(resolve(root, path), 'utf8')).version
   return {
     workspaceVersion: manifest('package.json'),
     vueVersion: manifest('packages/vue/package.json'),
     mcpVersion: manifest('packages/mcp/package.json'),
+  }
+}
+
+function githubPresence(path) {
+  const repository = process.env.GITHUB_REPOSITORY
+  if (!repository) throw new Error('GitHub release inspection requires GITHUB_REPOSITORY.')
+  const result = spawnSync('gh', ['api', `repos/${repository}/${path}`], { encoding: 'utf8' })
+  if (result.status === 0) return 'present'
+  if (/HTTP 404|Not Found/u.test(result.stderr)) return 'absent'
+  throw new Error(`GitHub release state is unavailable for ${path}: ${result.stderr.trim()}`)
+}
+
+async function verifyCompletedRelease(intent) {
+  const directory = mkdtempSync(join(tmpdir(), 'better-convex-intent-'))
+  try {
+    const download = spawnSync(
+      'gh',
+      [
+        'release',
+        'download',
+        intent.tag,
+        '--repo',
+        process.env.GITHUB_REPOSITORY,
+        '--dir',
+        directory,
+      ],
+      { encoding: 'utf8' },
+    )
+    if (download.status !== 0) {
+      throw new Error(`Could not download ${intent.tag} evidence: ${download.stderr.trim()}`)
+    }
+    const record = JSON.parse(readFileSync(join(directory, 'release-record.json'), 'utf8'))
+    if (
+      record.unit !== intent.id ||
+      record.version !== intent.version ||
+      record.tag !== intent.tag ||
+      JSON.stringify(record.packages.map(({ name }) => name)) !== JSON.stringify(intent.packages)
+    ) {
+      throw new Error(`${intent.tag} Release evidence does not match its manifest-derived unit.`)
+    }
+    return (await inspect(directory, record)).action
+  } finally {
+    rmSync(directory, { force: true, recursive: true })
   }
 }
 
@@ -67,31 +135,33 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8'),
     readVersions(),
   )
-  if (intents.length > 1) {
-    throw new Error(
-      `Multiple release intents are active (${intents.map((intent) => intent.tag).join(', ')}). Finish the earlier release before merging another intent.`,
-    )
+  const states = []
+  for (const intent of intents) {
+    const publications = intent.packages.map((name) => npmIntegrity(`${name}@${intent.version}`))
+    const initialState = classifyReleaseIntent({
+      publications,
+      tag: githubPresence(`git/ref/tags/${encodeURIComponent(intent.tag)}`),
+      release: githubPresence(`releases/tags/${encodeURIComponent(intent.tag)}`),
+    })
+    states.push({
+      intent,
+      publications,
+      state: initialState === 'verify' ? await verifyCompletedRelease(intent) : initialState,
+    })
   }
-  const intent = intents[0]
-  if (!intent) {
+  const selected = selectIncompleteIntent(states)
+  if (!selected) {
     if (output) appendFileSync(output, 'ready=false\naction=no-op\n')
     if (summary)
       appendFileSync(summary, '\n## Release candidate\n\nNo incomplete release intent exists.\n')
     process.exit(0)
   }
-  const state = classifyCandidateNeed(
-    intent.packages.map((name) => npmIntegrity(`${name}@${intent.version}`)),
-  )
-  if (state === 'partial') {
-    throw new Error(
-      `${intent.tag} is partially published. Reuse its retained candidate; never build replacement bytes.`,
-    )
-  }
+  const { intent, state } = selected
   const ready = state === 'build'
   if (output) {
     for (const [name, value] of Object.entries({
       ready: String(ready),
-      action: ready ? 'build' : 'reuse',
+      action: ready ? 'build' : 'repair',
       unit: intent.id,
       version: intent.version,
       channel: intent.channel,
@@ -103,6 +173,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   if (summary)
     appendFileSync(
       summary,
-      `\n## Release candidate\n\n- Intent: \`${intent.tag}\`\n- Unit: \`${intent.id}\`\n- Registry state: \`${state}\`\n- Next action: ${ready ? 'Build and retain the exact candidate once.' : 'Reuse the original retained candidate for reconciliation.'}\n`,
+      `\n## Release candidate\n\n- Intent: \`${intent.tag}\`\n- Unit: \`${intent.id}\`\n- Release state: \`${state}\`\n- Next action: ${ready ? 'Build and retain the exact candidate once.' : 'Reuse the original retained candidate for reconciliation; never build replacement bytes.'}\n`,
     )
 }

--- a/scripts/test-lazy-release.mjs
+++ b/scripts/test-lazy-release.mjs
@@ -4,9 +4,17 @@ import {
   assertFreshFirstAttempt,
   classifyReconciliation,
   evaluateProvenanceStatement,
+  isFirstPublicationAttempt,
+  releaseAssetFiles,
   releaseMetadataState,
 } from './reconcile-release.mjs'
-import { classifyCandidateNeed, detectReleaseIntents, releaseUnits } from './release-intent.mjs'
+import {
+  classifyCandidateNeed,
+  classifyReleaseIntent,
+  detectReleaseIntents,
+  releaseUnits,
+  selectIncompleteIntent,
+} from './release-intent.mjs'
 
 const versions = {
   workspaceVersion: '1.0.0-beta.1',
@@ -36,9 +44,57 @@ assert.throws(
   () => releaseUnits({ ...versions, vueVersion: '1.0.0-beta.2' }),
   /must remain coupled/u,
 )
+assert.equal(isFirstPublicationAttempt('publish', ['absent', 'absent']), true)
+assert.equal(isFirstPublicationAttempt('publish', ['oidc', 'absent']), false)
+assert.equal(isFirstPublicationAttempt('repair', ['oidc', 'oidc']), false)
 assert.equal(classifyCandidateNeed([null, null]), 'build')
 assert.equal(classifyCandidateNeed(['sha', 'sha']), 'reuse')
 assert.equal(classifyCandidateNeed(['sha', null]), 'partial')
+assert.equal(
+  classifyReleaseIntent({ publications: [null, null], tag: 'absent', release: 'absent' }),
+  'build',
+)
+
+assert.deepEqual(
+  releaseAssetFiles({
+    assets: [{ file: 'package.tgz' }, { file: 'artifact.json' }],
+  }),
+  ['artifact.json', 'github-release-notes.md', 'package.tgz', 'release-record.json'],
+)
+assert.equal(
+  classifyReleaseIntent({ publications: ['sha', 'sha'], tag: 'absent', release: 'absent' }),
+  'repair',
+)
+assert.equal(
+  classifyReleaseIntent({ publications: ['sha', 'sha'], tag: 'present', release: 'present' }),
+  'verify',
+)
+assert.equal(
+  classifyReleaseIntent({ publications: ['sha', null], tag: 'absent', release: 'absent' }),
+  'repair',
+)
+assert.throws(
+  () => classifyReleaseIntent({ publications: [null, null], tag: 'present', release: 'absent' }),
+  /before npm publication/u,
+)
+
+const [vueNuxt, mcp] = units
+assert.equal(
+  selectIncompleteIntent([
+    { intent: vueNuxt, state: 'complete' },
+    { intent: mcp, state: 'build' },
+  ]).intent.id,
+  'mcp',
+)
+assert.equal(selectIncompleteIntent([{ intent: vueNuxt, state: 'complete' }]), undefined)
+assert.throws(
+  () =>
+    selectIncompleteIntent([
+      { intent: vueNuxt, state: 'repair' },
+      { intent: mcp, state: 'build' },
+    ]),
+  /Multiple incomplete release intents/u,
+)
 
 const complete = {
   modes: ['oidc', 'oidc'],

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -48,8 +48,17 @@ assert(
 )
 assert(protectedSource.includes('--provenance') && protectedSource.includes('--ignore-scripts'))
 assert(
+  !protectedSource.includes('did not expose exact bytes, channel, and provenance'),
+  'The protected job must not fail on immediate npm propagation delay.',
+)
+assert(
   protectedSource.includes('record.publishOrder'),
   'The protected job must obey the certified publish order.',
+)
+assert(
+  protectedSource.includes("needs.verify.outputs.first-attempt == 'true'") &&
+    protectedSource.includes('git/ref/heads/main'),
+  'The protected job must recheck current main immediately before a first publication.',
 )
 
 const verify = publish.jobs.verify
@@ -67,13 +76,14 @@ for (const required of [
   "branch: 'main'",
   'listWorkflowRunArtifacts',
   'artifact.expired === false',
+  'for (const unit of units)',
+  'incompleteUnits.length > 1',
   "core.setOutput('active', 'false')",
   "core.setOutput('active', 'true')",
   'incomplete.length > 1',
   'const selected = incomplete[0] ?? retained[0]',
   "core.setOutput('run-id', String(selected.id))",
   "core.setOutput('sha', selected.head_sha)",
-  'github.run_attempt == 1',
 ])
   assert(verifySource.includes(required), `Candidate verification is missing ${required}.`)
 for (const step of verify.steps.slice(1)) {
@@ -101,6 +111,8 @@ for (const required of [
   'gh release create',
   'gh release view',
   'gh release edit',
+  'rm -f .release/registry-verification.json',
+  'gh release delete-asset',
 ]) {
   assert(publishSource.includes(required), `GitHub Release repair is missing ${required}.`)
 }
@@ -121,6 +133,28 @@ assert(
   ci.jobs['release-gate'].needs.includes('release-candidate'),
   'The required release-gate must aggregate candidate success.',
 )
+const intentStep = candidate.steps.find(
+  (step) => step.name === 'Derive the unique incomplete release intent',
+)
+assert.deepEqual(intentStep.env, { GH_TOKEN: '${{ github.token }}' })
+
+const publication = publish.jobs['verify-publication']
+assert.deepEqual(publication.needs, ['verify', 'publish-packages'])
+assert.deepEqual(publication.permissions, { actions: 'read', contents: 'read' })
+assert(!JSON.stringify(publication).includes('id-token'))
+assert(JSON.stringify(publication).includes('reconcile-release.mjs'))
+assert(JSON.stringify(publication).includes('for delay in 0 5 10 20 40 60'))
+assert(JSON.stringify(publication).includes("pkg.mode === 'oidc'"))
+assert(JSON.stringify(publication).includes('publication-verified-better-convex-release'))
+assert.deepEqual(release.needs, ['verify', 'verify-publication'])
+assert(JSON.stringify(release).includes('publication-verified-better-convex-release'))
+
+const completed = publish.jobs['verify-completed-release']
+assert.deepEqual(completed.needs, ['verify', 'github-release'])
+assert.deepEqual(completed.permissions, { actions: 'read', contents: 'read' })
+assert(!JSON.stringify(completed).includes('id-token'))
+assert(JSON.stringify(completed).includes('reconcile-release.mjs'))
+assert(completed.steps.some((step) => step.run === 'test "$ACTION" = complete'))
 
 for (const [path, source] of [
   ['ci.yml', ciSource],

--- a/scripts/update-candidate-app-locks.mjs
+++ b/scripts/update-candidate-app-locks.mjs
@@ -215,13 +215,15 @@ try {
       profile.packageIds.includes(packageId),
     )
     const validationWorkspacePath = join(validationDir, 'pnpm-workspace.yaml')
-    writeFileSync(
-      validationWorkspacePath,
-      withCandidateReleaseAgeExclusions(
-        readFileSync(validationWorkspacePath, 'utf8'),
-        requiredCandidates.map(({ artifact }) => artifact),
-      ),
-    )
+    if (existsSync(validationWorkspacePath)) {
+      writeFileSync(
+        validationWorkspacePath,
+        withCandidateReleaseAgeExclusions(
+          readFileSync(validationWorkspacePath, 'utf8'),
+          requiredCandidates.map(({ artifact }) => artifact),
+        ),
+      )
+    }
     if (options.check) {
       const committedLock = originalLocks.get(lockPath)
       for (const { artifact } of requiredCandidates) {

--- a/scripts/update-candidate-app-locks.mjs
+++ b/scripts/update-candidate-app-locks.mjs
@@ -215,15 +215,19 @@ try {
       profile.packageIds.includes(packageId),
     )
     const validationWorkspacePath = join(validationDir, 'pnpm-workspace.yaml')
-    if (existsSync(validationWorkspacePath)) {
-      writeFileSync(
-        validationWorkspacePath,
-        withCandidateReleaseAgeExclusions(
-          readFileSync(validationWorkspacePath, 'utf8'),
-          requiredCandidates.map(({ artifact }) => artifact),
-        ),
-      )
-    }
+    // Standalone starters inherit the repository policy in normal use but have
+    // no workspace file of their own. Give the isolated validation copy a
+    // minimal policy file so only the exact local candidates bypass quarantine.
+    const workspaceSource = existsSync(validationWorkspacePath)
+      ? readFileSync(validationWorkspacePath, 'utf8')
+      : 'packages: []\n'
+    writeFileSync(
+      validationWorkspacePath,
+      withCandidateReleaseAgeExclusions(
+        workspaceSource,
+        requiredCandidates.map(({ artifact }) => artifact),
+      ),
+    )
     if (options.check) {
       const committedLock = originalLocks.get(lockPath)
       for (const { artifact } of requiredCandidates) {

--- a/scripts/update-candidate-app-locks.mjs
+++ b/scripts/update-candidate-app-locks.mjs
@@ -22,6 +22,7 @@ import {
   candidateAppLockProfiles,
   createCandidateRegistryMetadata,
   packageArtifactIdentity,
+  withCandidateReleaseAgeExclusions,
 } from './candidate-app-locks.mjs'
 import { getPackageArtifactCoordinates } from './package-artifact-coordinates.mjs'
 import { assertPackedRuntimeFingerprintBinding } from './package-runtime-fingerprint-profile.mjs'
@@ -212,6 +213,14 @@ try {
     const validationLockPath = join(validationDir, 'pnpm-lock.yaml')
     const requiredCandidates = candidates.filter(({ packageId }) =>
       profile.packageIds.includes(packageId),
+    )
+    const validationWorkspacePath = join(validationDir, 'pnpm-workspace.yaml')
+    writeFileSync(
+      validationWorkspacePath,
+      withCandidateReleaseAgeExclusions(
+        readFileSync(validationWorkspacePath, 'utf8'),
+        requiredCandidates.map(({ artifact }) => artifact),
+      ),
     )
     if (options.check) {
       const committedLock = originalLocks.get(lockPath)

--- a/test/release-control/candidate-app-locks.test.ts
+++ b/test/release-control/candidate-app-locks.test.ts
@@ -14,6 +14,7 @@ import {
   candidateAppLockProfiles,
   createCandidateRegistryMetadata,
   packageArtifactIdentity,
+  withCandidateReleaseAgeExclusions,
 } from '../../scripts/candidate-app-locks.mjs'
 import { getMaintainedCandidateProfile } from '../../scripts/maintained-candidate-apps.mjs'
 import { getPackageArtifactCoordinates } from '../../scripts/package-artifact-coordinates.mjs'
@@ -116,6 +117,20 @@ function writeCandidateTarball(
 }
 
 describe('candidate app lock contract', () => {
+  it('exempts only exact certified candidates in temporary workspaces', () => {
+    const artifact = packageArtifactIdentity(
+      'nuxt',
+      '1.0.0-beta.1',
+      `sha512-${Buffer.alloc(64).toString('base64')}`,
+    )
+    expect(withCandidateReleaseAgeExclusions('minimumReleaseAge: 1440\n', [artifact])).toBe(
+      "minimumReleaseAge: 1440\nminimumReleaseAgeExclude:\n  - '@lupinum/better-convex-nuxt@1.0.0-beta.1'\n",
+    )
+    expect(() =>
+      withCandidateReleaseAgeExclusions('minimumReleaseAgeExclude:\n', [artifact]),
+    ).toThrow(/already contains/u)
+  })
+
   it('derives all maintained starters and adds only the standalone demo', () => {
     const maintained = getMaintainedCandidateProfile('nuxt').profile.pnpmApps.map(
       (entry: { path: string }) => entry.path,

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -7,6 +7,7 @@ import { parse } from 'yaml'
 const root = resolve(import.meta.dirname, '../..')
 
 interface WorkflowStep {
+  env?: Record<string, unknown>
   if?: unknown
   name?: string
   run?: unknown
@@ -101,6 +102,10 @@ describe('state-aware Better Convex release workflows', () => {
       name: 'release-candidate',
       'retention-days': 90,
     })
+    const intent = requireJob(ci, 'release-candidate').steps?.find(
+      ({ name }) => name === 'Derive the unique incomplete release intent',
+    )
+    expect(intent?.env).toEqual({ GH_TOKEN: '${{ github.token }}' })
   })
 
   it('starts from successful CI or an input-free reconciliation dispatch', () => {
@@ -117,6 +122,8 @@ describe('state-aware Better Convex release workflows', () => {
     expect(JSON.stringify(requireJob(publish, 'verify'))).toContain(
       "core.setOutput('active', 'false')",
     )
+    expect(JSON.stringify(requireJob(publish, 'verify'))).toContain('for (const unit of units)')
+    expect(JSON.stringify(requireJob(publish, 'verify'))).toContain('incompleteUnits.length > 1')
     for (const step of requireJob(publish, 'verify').steps?.slice(1) ?? []) {
       expect(step.if).toBe("steps.ci.outputs.active == 'true'")
     }
@@ -147,20 +154,44 @@ describe('state-aware Better Convex release workflows', () => {
     expect(serializedSteps).toContain("'--provenance'")
     expect(serializedSteps).toContain('record.publishOrder')
     expect(serializedSteps).toContain("evidence.mode === 'absent'")
+    expect(serializedSteps).not.toContain('did not expose exact bytes, channel, and provenance')
+    expect(serializedSteps).toContain("needs.verify.outputs.first-attempt == 'true'")
+    expect(serializedSteps).toContain('git/ref/heads/main')
   })
 
-  it('repairs GitHub history without rebuilding or republishing', () => {
-    expect(needs(publish, 'github-release')).toEqual(['verify', 'publish-packages'])
+  it('proves publication and public history without privileged source execution', () => {
+    const publication = requireJob(publish, 'verify-publication')
+    expect(needs(publish, 'verify-publication')).toEqual(['verify', 'publish-packages'])
+    expect(publication.permissions).toEqual({ actions: 'read', contents: 'read' })
+    expect(JSON.stringify(publication)).not.toContain('id-token')
+    expect(runs(publish, 'verify-publication').join('\n')).toContain('reconcile-release.mjs')
+    expect(runs(publish, 'verify-publication').join('\n')).toContain('for delay in 0 5 10 20 40 60')
+    expect(runs(publish, 'verify-publication').join('\n')).toContain("pkg.mode === 'oidc'")
+    expect(JSON.stringify(publication)).toContain('publication-verified-better-convex-release')
+
+    expect(needs(publish, 'github-release')).toEqual(['verify', 'verify-publication'])
     const releaseJob = requireJob(publish, 'github-release')
     expect(releaseJob.permissions).toEqual({
       actions: 'read',
       contents: 'write',
     })
+    expect(JSON.stringify(releaseJob)).toContain('publication-verified-better-convex-release')
     const source = runs(publish, 'github-release').join('\n')
     expect(source).toContain('HUMAN-ONLY: GitHub could not create historical tag')
     expect(source).toContain('rerun only this failed Release job')
     expect(source).toContain('git tag $RELEASE_TAG $SOURCE_SHA')
+    expect(source).toContain('rm -f .release/registry-verification.json')
+    expect(source).toContain('gh release delete-asset')
     expect(source).not.toMatch(/npm publish|pnpm|corepack|npm install|release:artifact/u)
+
+    const completed = requireJob(publish, 'verify-completed-release')
+    expect(needs(publish, 'verify-completed-release')).toEqual(['verify', 'github-release'])
+    expect(completed.permissions).toEqual({ actions: 'read', contents: 'read' })
+    expect(JSON.stringify(completed)).not.toContain('id-token')
+    expect(runs(publish, 'verify-completed-release').join('\n')).toContain('reconcile-release.mjs')
+    expect(runs(publish, 'verify-completed-release').join('\n')).toContain(
+      'test "$ACTION" = complete',
+    )
   })
 
   it('pins actions and keeps default permissions read-only', () => {


### PR DESCRIPTION
## Result

The first Lazy Maintainer release published both Vue/Nuxt packages successfully, but npm metadata propagation made the protected job report failure. Completed changelog intents also remained active, and a derived pre-publication report was treated as an immutable Release asset. That made reconciliation repeat forever and blocked the independent MCP release.

Reconciliation now waits for npm propagation outside the protected job, deeply proves completed release units, keeps derived registry state out of the public asset contract, removes unexpected Release assets, and verifies the final completed state. Manual recovery can distinguish completed Vue/Nuxt history from the next MCP intent without rebuilding or republishing.

## Verification

- [x] I ran `pnpm verify`.
- `pnpm verify`: 189 test files and 2,158 tests passed, plus audits, ASVS checks, SBOM contracts, and the documentation build.
- Focused candidate-lock tests passed after the exact release-age isolation fix.
- GitHub CI passed source certification, all four packed-dependency lanes, candidate apps, auth contracts, compatibility, Linux `release-smoke`, and the final `release-gate`.
- The live read-only detector classified `v1.0.0-beta.1` as `repair`; only the obsolete derived Release asset remains.
- CodeRabbit reported no actionable findings on the core patch. Its later run was rate-limited; the full GitHub suite passed at the final head.

## Documentation and compatibility

- [x] I updated public documentation when behavior changed.
- [x] I added tests for the changed invariant or failure boundary.
- [x] I updated versions, migration guidance, and compatibility notes when the public contract changed. No package version or public API changed in this PR.
- [x] I kept application authorization in Convex.
- [x] I kept server-only code outside browser bundles.
- [x] I kept this pull request focused on one concern.
- [x] I did not include credentials, tokens, private data, or generated artifacts.

## Release note

None. This repairs release automation and documentation; it does not change published package bytes or public APIs.

## Risk

The main risk is incorrectly treating a partial or conflicting publication as complete. The detector fails closed on registry uncertainty, verifies exact bytes and Sigstore provenance, checks the certified source and workflow identity, reconciles only retained artifacts, and now passes the repository’s full release-policy and Linux smoke suites.
