### PR TITLE
fix(release): make historical reconciliation converge

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -36,6 +36,15 @@ jobs:
       unit: ${{ steps.state.outputs.unit }}
       version: ${{ steps.state.outputs.version }}
     steps:
+      - name: Require the protected verifier ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          VERIFIER_REF: ${{ github.ref }}
+        run: |
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$VERIFIER_REF" != refs/heads/main ]; then
+            echo 'Manual reconciliation must be dispatched from the protected main branch.' >&2
+            exit 1
+          fi
       - name: Select one unique incomplete CI candidate
         id: ci
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.ci.outputs.active == 'true'
         with:
-          ref: ${{ steps.ci.outputs.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.ci.outputs.active == 'true'
@@ -242,7 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.verify.outputs.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -380,7 +380,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.verify.outputs.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,6 +83,11 @@ The protected job checks current `main` again immediately before that first
 publication, so an approval wait cannot make the candidate stale. Reruns reuse
 the original retained candidate even after `main` advances.
 
+Reconciliation runs the verifier from the trusted workflow commit against the
+original retained candidate and its certified source SHA. It does not execute
+an older verifier from the historical package commit, so safety fixes can
+repair existing releases without changing their bytes or provenance.
+
 After the protected job, an unprivileged verifier proves the published bytes,
 channel, Sigstore certificate identity, source SHA, and trusted workflow identity
 before GitHub history is reconciled. This verifier uses a bounded retry window

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,9 +84,11 @@ publication, so an approval wait cannot make the candidate stale. Reruns reuse
 the original retained candidate even after `main` advances.
 
 Reconciliation runs the verifier from the trusted workflow commit against the
-original retained candidate and its certified source SHA. It does not execute
-an older verifier from the historical package commit, so safety fixes can
-repair existing releases without changing their bytes or provenance.
+original retained candidate and its certified source SHA. Manual reconciliation
+must be dispatched from the protected `main` branch; any other selected ref
+fails before checkout. It does not execute an older verifier from the historical
+package commit, so safety fixes can repair existing releases without changing
+their bytes or provenance.
 
 After the protected job, an unprivileged verifier proves the published bytes,
 channel, Sigstore certificate identity, source SHA, and trusted workflow identity

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -68,6 +68,18 @@ assert(
     String(verify.if).includes("workflow_run.event == 'push'") &&
     String(verify.if).includes("workflow_run.head_branch == 'main'"),
 )
+const verifierRefGuard = verify.steps[0]
+assert.equal(verifierRefGuard.name, 'Require the protected verifier ref')
+assert.deepEqual(verifierRefGuard.env, {
+  EVENT_NAME: '${{ github.event_name }}',
+  VERIFIER_REF: '${{ github.ref }}',
+})
+assert(
+  verifierRefGuard.run.includes('workflow_dispatch') &&
+    verifierRefGuard.run.includes('refs/heads/main') &&
+    verifierRefGuard.run.includes('exit 1'),
+  'A manual reconciliation from a non-main ref must fail before checkout.',
+)
 const verifySource = JSON.stringify(verify)
 for (const required of [
   "workflow_id: 'ci.yml'",
@@ -86,7 +98,7 @@ for (const required of [
   "core.setOutput('sha', selected.head_sha)",
 ])
   assert(verifySource.includes(required), `Candidate verification is missing ${required}.`)
-for (const step of verify.steps.slice(1)) {
+for (const step of verify.steps.slice(2)) {
   assert.equal(
     step.if,
     "steps.ci.outputs.active == 'true'",

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -98,6 +98,19 @@ assert(
     verifySource.includes('registry-verification.json') === false,
   'The unprivileged verifier must derive registry evidence before approval.',
 )
+const verifierJobs = [
+  verify,
+  publish.jobs['verify-publication'],
+  publish.jobs['verify-completed-release'],
+]
+for (const job of verifierJobs) {
+  const checkout = job.steps.find((step) => String(step.uses ?? '').startsWith('actions/checkout@'))
+  assert.equal(
+    checkout?.with?.ref,
+    '${{ github.sha }}',
+    'Reconciliation must use the current trusted verifier against retained evidence.',
+  )
+}
 
 const release = publish.jobs['github-release']
 assert.equal(release.permissions.contents, 'write')

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -130,7 +130,18 @@ describe('state-aware Better Convex release workflows', () => {
     )
     expect(JSON.stringify(requireJob(publish, 'verify'))).toContain('for (const unit of units)')
     expect(JSON.stringify(requireJob(publish, 'verify'))).toContain('incompleteUnits.length > 1')
-    for (const step of requireJob(publish, 'verify').steps?.slice(1) ?? []) {
+    const verifierRefGuard = requireJob(publish, 'verify').steps?.[0]
+    expect(verifierRefGuard).toMatchObject({
+      name: 'Require the protected verifier ref',
+      env: {
+        EVENT_NAME: '${{ github.event_name }}',
+        VERIFIER_REF: '${{ github.ref }}',
+      },
+    })
+    expect(verifierRefGuard?.run).toContain('workflow_dispatch')
+    expect(verifierRefGuard?.run).toContain('refs/heads/main')
+    expect(verifierRefGuard?.run).toContain('exit 1')
+    for (const step of requireJob(publish, 'verify').steps?.slice(2) ?? []) {
       expect(step.if).toBe("steps.ci.outputs.active == 'true'")
     }
     expect(requireJob(publish, 'verify').permissions).toEqual({

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -62,6 +62,12 @@ function uses(workflow: Workflow) {
   )
 }
 
+function checkoutRef(workflow: Workflow, jobId: string) {
+  return requireJob(workflow, jobId).steps?.find(({ uses }) =>
+    String(uses ?? '').startsWith('actions/checkout@'),
+  )?.with?.ref
+}
+
 describe('state-aware Better Convex release workflows', () => {
   const ci = parseWorkflow('.github/workflows/ci.yml')
   const publish = parseWorkflow('.github/workflows/publish-prerelease.yml')
@@ -131,6 +137,7 @@ describe('state-aware Better Convex release workflows', () => {
       actions: 'read',
       contents: 'read',
     })
+    expect(checkoutRef(publish, 'verify')).toBe('${{ github.sha }}')
   })
 
   it('uses one protected OIDC job without privileged source execution', () => {
@@ -168,6 +175,7 @@ describe('state-aware Better Convex release workflows', () => {
     expect(runs(publish, 'verify-publication').join('\n')).toContain('for delay in 0 5 10 20 40 60')
     expect(runs(publish, 'verify-publication').join('\n')).toContain("pkg.mode === 'oidc'")
     expect(JSON.stringify(publication)).toContain('publication-verified-better-convex-release')
+    expect(checkoutRef(publish, 'verify-publication')).toBe('${{ github.sha }}')
 
     expect(needs(publish, 'github-release')).toEqual(['verify', 'verify-publication'])
     const releaseJob = requireJob(publish, 'github-release')
@@ -192,6 +200,7 @@ describe('state-aware Better Convex release workflows', () => {
     expect(runs(publish, 'verify-completed-release').join('\n')).toContain(
       'test "$ACTION" = complete',
     )
+    expect(checkoutRef(publish, 'verify-completed-release')).toBe('${{ github.sha }}')
   })
 
   it('pins actions and keeps default permissions read-only', () => {


### PR DESCRIPTION
## Result

Historical release reconciliation executed the verifier from the certified package commit. That meant a release could be repaired with current policy but then fail its final check with the older verifier.

Reconciliation now runs the current trusted workflow verifier against the original retained candidate and certified source SHA. The package bytes, provenance, and release source remain unchanged; only the read-only verification policy comes from the workflow being reviewed.

## Verification

- `git diff --check`
- `node scripts/test-release-workflow.mjs`
- `pnpm exec vitest run test/release-control/release-workflow.test.ts`
- `pnpm verify`
- Live read-only reconciliation of `v1.0.0-beta.1` with the current verifier classified the existing npm packages, tag, GitHub prerelease, and retained assets as `complete`.

- [x] I ran `pnpm verify`, or I explained why it does not apply.

## Documentation and compatibility

- [x] I updated public documentation when behavior changed.
- [x] I added tests for the changed invariant or failure boundary.
- [x] I updated versions, migration guidance, and compatibility notes when the public contract changed.
- [x] I kept application authorization in Convex.
- [x] I kept server-only code outside browser bundles.
- [x] I kept this pull request focused on one concern.
- [x] I did not include credentials, tokens, private data, or generated artifacts.

## Release note

None. This corrects repository-owned release orchestration and does not change published package code.

## Risk

The current verifier could otherwise drift from historical evidence. The workflow controls this by retaining and verifying the exact candidate record, source SHA, package hashes, npm bytes, provenance, tag, and Release assets in unprivileged jobs. The protected publish job still checks out no repository source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved prerelease verification and release reconciliation by consistently using the trusted workflow revision while checking retained release evidence.
  * Existing release artifacts remain unchanged during reconciliation.

* **Documentation**
  * Clarified hosted source certification and reconciliation behavior.

* **Tests**
  * Added coverage confirming all reconciliation jobs use the expected trusted revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->