### PR TITLE
fix(release): verify MCP candidate with reviewed backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,9 @@ jobs:
         run: pnpm release:verify:set "${{ steps.candidate_set.outputs.evidence }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Install the reviewed MCP conformance backend
+        if: steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'
+        run: pnpm check:auth-backend --install
       - name: Verify the MCP unit
         if: steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'
         run: pnpm release:verify --package mcp --artifact-manifest "${{ steps.mcp.outputs.evidence }}"

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -170,6 +170,11 @@ assert.equal(
   "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
 )
 assert.equal(mcpBackend.run, 'pnpm check:auth-backend --install')
+assert(
+  candidate.steps.indexOf(mcpBackend) <
+    candidate.steps.findIndex((step) => step.name === 'Verify the MCP unit'),
+  'The reviewed MCP backend must be installed before MCP verification.',
+)
 
 const publication = publish.jobs['verify-publication']
 assert.deepEqual(publication.needs, ['verify', 'publish-packages'])

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -162,6 +162,14 @@ const intentStep = candidate.steps.find(
   (step) => step.name === 'Derive the unique incomplete release intent',
 )
 assert.deepEqual(intentStep.env, { GH_TOKEN: '${{ github.token }}' })
+const mcpBackend = candidate.steps.find(
+  (step) => step.name === 'Install the reviewed MCP conformance backend',
+)
+assert.equal(
+  mcpBackend.if,
+  "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
+)
+assert.equal(mcpBackend.run, 'pnpm check:auth-backend --install')
 
 const publication = publish.jobs['verify-publication']
 assert.deepEqual(publication.needs, ['verify', 'publish-packages'])

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -119,6 +119,11 @@ describe('state-aware Better Convex release workflows', () => {
       if: "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
       run: 'pnpm check:auth-backend --install',
     })
+    expect(requireJob(ci, 'release-candidate').steps?.indexOf(mcpBackend!)).toBeLessThan(
+      requireJob(ci, 'release-candidate').steps?.findIndex(
+        ({ name }) => name === 'Verify the MCP unit',
+      ) ?? -1,
+    )
   })
 
   it('starts from successful CI or an input-free reconciliation dispatch', () => {

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -112,6 +112,13 @@ describe('state-aware Better Convex release workflows', () => {
       ({ name }) => name === 'Derive the unique incomplete release intent',
     )
     expect(intent?.env).toEqual({ GH_TOKEN: '${{ github.token }}' })
+    const mcpBackend = requireJob(ci, 'release-candidate').steps?.find(
+      ({ name }) => name === 'Install the reviewed MCP conformance backend',
+    )
+    expect(mcpBackend).toMatchObject({
+      if: "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
+      run: 'pnpm check:auth-backend --install',
+    })
   })
 
   it('starts from successful CI or an input-free reconciliation dispatch', () => {


### PR DESCRIPTION
## Result

The first MCP `1.0.0-beta.1` candidate passed immutable-byte verification, packed exports, exact-tarball consumers, and all 56 MCP tests, but failed before retention because the candidate job had not installed the pinned local Convex backend required by the Better Auth conformance consumer.

The MCP candidate path now installs that same reviewed backend before artifact verification. This step is MCP-only, runs in unprivileged CI, and does not alter or rebuild Vue/Nuxt.

## Verification

- Failed run evidence: [candidate verification run 32784066465](https://github.com/lupinum-dev/better-convex/actions/runs/32784066465)
- `git diff --check`
- `node scripts/test-release-workflow.mjs`
- `node scripts/test-lazy-release.mjs`
- `pnpm exec vitest run test/release-control/release-workflow.test.ts`
- `pnpm exec oxfmt --check scripts/test-release-workflow.mjs test/release-control/release-workflow.test.ts`

- [ ] I ran `pnpm verify`, or I explained why it does not apply.

The full source suite already passed on the exact MCP intent SHA. This focused workflow correction is covered by both release-policy suites; this PR's full GitHub CI is the authoritative Linux verification of the missing backend install.

## Documentation and compatibility

- [x] I updated public documentation when behavior changed.
- [x] I added tests for the changed invariant or failure boundary.
- [x] I updated versions, migration guidance, and compatibility notes when the public contract changed.
- [x] I kept application authorization in Convex.
- [x] I kept server-only code outside browser bundles.
- [x] I kept this pull request focused on one concern.
- [x] I did not include credentials, tokens, private data, or generated artifacts.

## Release note

None. This fixes repository-owned MCP candidate verification and does not change package behavior.

## Risk

The candidate could otherwise pass source tests but fail its exact-tarball Better Auth conformance check. The install command is pinned by the existing backend checker and runs only when the manifest-derived release unit is `mcp`, before immutable record creation or artifact upload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP release candidates now automatically install the reviewed conformance backend when the MCP release intent is ready.
  * Release verification runs the backend installation before checking MCP release artifacts.

* **Tests**
  * Added coverage to verify the installation step runs only for ready MCP releases and uses the expected command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->