### PR TITLE
fix(release): install MCP conformance browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,9 @@ jobs:
       - name: Install the reviewed MCP conformance backend
         if: steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'
         run: pnpm check:auth-backend --install
+      - name: Install the reviewed MCP conformance browser
+        if: steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'
+        run: pnpm exec playwright install --with-deps chromium
       - name: Verify the MCP unit
         if: steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'
         run: pnpm release:verify --package mcp --artifact-manifest "${{ steps.mcp.outputs.evidence }}"

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -175,6 +175,19 @@ assert(
     candidate.steps.findIndex((step) => step.name === 'Verify the MCP unit'),
   'The reviewed MCP backend must be installed before MCP verification.',
 )
+const mcpBrowser = candidate.steps.find(
+  (step) => step.name === 'Install the reviewed MCP conformance browser',
+)
+assert.equal(
+  mcpBrowser.if,
+  "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
+)
+assert.equal(mcpBrowser.run, 'pnpm exec playwright install --with-deps chromium')
+assert(
+  candidate.steps.indexOf(mcpBrowser) <
+    candidate.steps.findIndex((step) => step.name === 'Verify the MCP unit'),
+  'The reviewed MCP browser must be installed before MCP verification.',
+)
 
 const publication = publish.jobs['verify-publication']
 assert.deepEqual(publication.needs, ['verify', 'publish-packages'])

--- a/test/release-control/release-workflow.test.ts
+++ b/test/release-control/release-workflow.test.ts
@@ -124,6 +124,18 @@ describe('state-aware Better Convex release workflows', () => {
         ({ name }) => name === 'Verify the MCP unit',
       ) ?? -1,
     )
+    const mcpBrowser = requireJob(ci, 'release-candidate').steps?.find(
+      ({ name }) => name === 'Install the reviewed MCP conformance browser',
+    )
+    expect(mcpBrowser).toMatchObject({
+      if: "steps.intent.outputs.ready == 'true' && steps.intent.outputs.unit == 'mcp'",
+      run: 'pnpm exec playwright install --with-deps chromium',
+    })
+    expect(requireJob(ci, 'release-candidate').steps?.indexOf(mcpBrowser!)).toBeLessThan(
+      requireJob(ci, 'release-candidate').steps?.findIndex(
+        ({ name }) => name === 'Verify the MCP unit',
+      ) ?? -1,
+    )
   })
 
   it('starts from successful CI or an input-free reconciliation dispatch', () => {


### PR DESCRIPTION
## Result

The exact MCP `1.0.0-beta.1` candidate passed immutable-byte verification, packed exports, exact-tarball consumers, the Better Auth build, and all 56 MCP tests. Its final conformance runner then failed because the candidate job had not installed the Playwright Chromium binary already required and installed by source CI.

The MCP-only candidate path now installs that reviewed browser before verification. Vue/Nuxt candidate steps remain skipped.

## Evidence

- [Failed candidate run 32787666804](https://github.com/lupinum-dev/better-convex/actions/runs/32787666804)
- Exact artifact SHA-256 before the browser failure: `bf767b6197300867e5ec9f37cf8474b1e3ca05f66964b3f9860b3be823889b7a`
- `node scripts/test-release-workflow.mjs`
- `node scripts/test-lazy-release.mjs`
- `pnpm exec vitest run test/release-control/release-workflow.test.ts`
- `pnpm exec oxfmt --check scripts/test-release-workflow.mjs test/release-control/release-workflow.test.ts`
- `git diff --check`

The policy tests prove the browser install is MCP-only and remains before MCP verification.

## Release safety

No candidate was retained and no package, tag, Release, or dist-tag was created by the failed run. This PR does not alter package source or the Vue/Nuxt release path.
