### PR TITLE
docs: show community links in the header

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -15,6 +15,7 @@ export default {
         { label: { en: 'Privacy' }, to: 'https://lupinum.com/datenschutz' },
       ],
     },
+    nav: { links: 'auto', socialIcons: true },
     social: {
       github: 'https://github.com/lupinum-dev/better-convex',
       discord: 'https://discord.gg/RPH6SeA36N',


### PR DESCRIPTION
The Better Convex documentation header did not expose the fleet GitHub and Discord links, which made it inconsistent with Nuxt Tour and the shared Nuxt documentation experience.

This change enables the existing Ginko Docs social icon controls. It uses the repository's configured links and keeps the neutral, theme-aware icon treatment supplied by the shared theme.

Verification:
- Built the documentation app through the Nuxt production build path.
- Verified the desktop and mobile header in the local browser.
- Confirmed the GitHub and Discord controls resolve to the configured destinations.

Generated with Codex (GPT-5.6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation navigation links are now generated automatically.
  * Social media icons are now enabled on the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->