### PR TITLE
fix(mcp): require a live session for delete approval

### DIFF
--- a/starters/mcp-oauth-agent/convex/approvals.ts
+++ b/starters/mcp-oauth-agent/convex/approvals.ts
@@ -1,17 +1,17 @@
 import { ConvexError, v } from 'convex/values'
 
 import { mutation } from './_generated/server'
+import { authComponent } from './auth'
 
 export const approveProjectDelete = mutation({
   args: { approvalId: v.id('approvals') },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity()
-    if (!identity) throw new ConvexError('Unauthenticated')
-    const claims = identity as unknown as Record<string, unknown>
-    if (claims.token_use !== 'convex-session') throw new ConvexError('Unauthenticated')
+    const authUser = await authComponent.safeGetAuthUser(ctx)
+    if (!authUser || typeof authUser.id !== 'string') throw new ConvexError('Unauthenticated')
+    const authId = authUser.id
     const user = await ctx.db
       .query('users')
-      .withIndex('by_auth_id', (q) => q.eq('authId', identity.subject))
+      .withIndex('by_auth_id', (q) => q.eq('authId', authId))
       .unique()
     const approval = await ctx.db.get(args.approvalId)
     if (!user || !user.active || !approval || approval.status !== 'pending') {

--- a/test/mcp/destructive-approval-session.test.ts
+++ b/test/mcp/destructive-approval-session.test.ts
@@ -10,12 +10,15 @@ import schema from '../../starters/mcp-oauth-agent/convex/schema'
 
 const rootModules = import.meta.glob('../../starters/mcp-oauth-agent/convex/**/*.ts')
 const authModules = import.meta.glob('../../src/runtime/convex-auth/component/**/*.ts')
-const components = componentsGeneric() as unknown as { betterAuth: ComponentApi<'betterAuth'> }
+const components = componentsGeneric() as unknown as {
+  betterAuth: ComponentApi<'betterAuth'>
+}
 const approveProjectDelete = makeFunctionReference<'mutation', { approvalId: string }, string>(
   'approvals:approveProjectDelete',
 )
 
 const now = Date.now()
+const authSessionId = 'admin-session-id'
 const authUser = {
   id: 'admin-auth-id',
   name: 'Admin',
@@ -25,27 +28,33 @@ const authUser = {
   createdAt: now,
   updatedAt: now,
 }
-const authSession = {
-  id: 'admin-session-id',
-  userId: authUser.id,
-  token: 'admin-session-token',
-  createdAt: now,
-  updatedAt: now,
-  expiresAt: now + 60_000,
-  ipAddress: null,
-  userAgent: null,
-}
 const identity = {
   subject: authUser.id,
-  sid: authSession.id,
+  sid: authSessionId,
   token_use: 'convex-session',
 }
 
-async function setup() {
+async function setup({ sessionExpiresAt }: { sessionExpiresAt?: number } = {}) {
   const test = convexTest(schema, rootModules)
   test.registerComponent('betterAuth', authSchema, authModules)
-  await test.mutation(components.betterAuth.adapter.create, { model: 'user', data: authUser })
-  await test.mutation(components.betterAuth.adapter.create, { model: 'session', data: authSession })
+  await test.mutation(components.betterAuth.adapter.create, {
+    model: 'user',
+    data: authUser,
+  })
+  const setupAt = Date.now()
+  await test.mutation(components.betterAuth.adapter.create, {
+    model: 'session',
+    data: {
+      id: authSessionId,
+      userId: authUser.id,
+      token: 'admin-session-token',
+      createdAt: setupAt,
+      updatedAt: setupAt,
+      expiresAt: sessionExpiresAt ?? setupAt + 60_000,
+      ipAddress: null,
+      userAgent: null,
+    },
+  })
   const ids = await test.run(async (ctx) => {
     const adminId = await ctx.db.insert('users', {
       authId: authUser.id,
@@ -61,7 +70,9 @@ async function setup() {
       active: true,
       oauthAdmin: false,
     })
-    const organizationId = await ctx.db.insert('organizations', { name: 'Test' })
+    const organizationId = await ctx.db.insert('organizations', {
+      name: 'Test',
+    })
     await ctx.db.insert('memberships', {
       organizationId,
       userId: adminId,
@@ -81,7 +92,7 @@ async function setup() {
       userId: requesterId,
       clientId: 'requester-client',
       status: 'pending',
-      expiresAt: now + 60_000,
+      expiresAt: setupAt + 60_000,
     })
     return { adminId, approvalId }
   })
@@ -105,7 +116,20 @@ describe('destructive project approval', () => {
     const { test, approvalId } = await setup()
     await test.mutation(components.betterAuth.adapter.deleteOne, {
       model: 'session',
-      where: [{ field: 'id', value: authSession.id }],
+      where: [{ field: 'id', value: authSessionId }],
+    })
+
+    await expect(
+      test.withIdentity(identity).mutation(approveProjectDelete, { approvalId }),
+    ).rejects.toMatchObject({ data: 'Unauthenticated' })
+    await expect(test.run((ctx) => ctx.db.get(approvalId))).resolves.toMatchObject({
+      status: 'pending',
+    })
+  })
+
+  it('rejects the same JWT after its canonical session expires', async () => {
+    const { test, approvalId } = await setup({
+      sessionExpiresAt: Date.now() - 60_000,
     })
 
     await expect(

--- a/test/mcp/destructive-approval-session.test.ts
+++ b/test/mcp/destructive-approval-session.test.ts
@@ -1,0 +1,118 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from 'convex-test'
+import { componentsGeneric, makeFunctionReference } from 'convex/server'
+import { describe, expect, it } from 'vitest'
+
+import type { ComponentApi } from '../../src/runtime/convex-auth/component/_generated/component'
+import authSchema from '../../src/runtime/convex-auth/component/schema'
+import schema from '../../starters/mcp-oauth-agent/convex/schema'
+
+const rootModules = import.meta.glob('../../starters/mcp-oauth-agent/convex/**/*.ts')
+const authModules = import.meta.glob('../../src/runtime/convex-auth/component/**/*.ts')
+const components = componentsGeneric() as unknown as { betterAuth: ComponentApi<'betterAuth'> }
+const approveProjectDelete = makeFunctionReference<'mutation', { approvalId: string }, string>(
+  'approvals:approveProjectDelete',
+)
+
+const now = Date.now()
+const authUser = {
+  id: 'admin-auth-id',
+  name: 'Admin',
+  email: 'admin@example.test',
+  emailVerified: true,
+  image: null,
+  createdAt: now,
+  updatedAt: now,
+}
+const authSession = {
+  id: 'admin-session-id',
+  userId: authUser.id,
+  token: 'admin-session-token',
+  createdAt: now,
+  updatedAt: now,
+  expiresAt: now + 60_000,
+  ipAddress: null,
+  userAgent: null,
+}
+const identity = {
+  subject: authUser.id,
+  sid: authSession.id,
+  token_use: 'convex-session',
+}
+
+async function setup() {
+  const test = convexTest(schema, rootModules)
+  test.registerComponent('betterAuth', authSchema, authModules)
+  await test.mutation(components.betterAuth.adapter.create, { model: 'user', data: authUser })
+  await test.mutation(components.betterAuth.adapter.create, { model: 'session', data: authSession })
+  const ids = await test.run(async (ctx) => {
+    const adminId = await ctx.db.insert('users', {
+      authId: authUser.id,
+      email: authUser.email,
+      name: authUser.name,
+      active: true,
+      oauthAdmin: false,
+    })
+    const requesterId = await ctx.db.insert('users', {
+      authId: 'requester-auth-id',
+      email: 'requester@example.test',
+      name: 'Requester',
+      active: true,
+      oauthAdmin: false,
+    })
+    const organizationId = await ctx.db.insert('organizations', { name: 'Test' })
+    await ctx.db.insert('memberships', {
+      organizationId,
+      userId: adminId,
+      role: 'admin',
+      status: 'active',
+    })
+    const projectId = await ctx.db.insert('projects', {
+      organizationId,
+      name: 'Protected project',
+      status: 'active',
+      createdBy: requesterId,
+    })
+    const approvalId = await ctx.db.insert('approvals', {
+      operation: 'projects.delete',
+      projectId,
+      organizationId,
+      userId: requesterId,
+      clientId: 'requester-client',
+      status: 'pending',
+      expiresAt: now + 60_000,
+    })
+    return { adminId, approvalId }
+  })
+  return { test, ...ids }
+}
+
+describe('destructive project approval', () => {
+  it('accepts an active administrator with a live canonical session', async () => {
+    const { test, adminId, approvalId } = await setup()
+
+    await expect(
+      test.withIdentity(identity).mutation(approveProjectDelete, { approvalId }),
+    ).resolves.toBe(approvalId)
+    await expect(test.run((ctx) => ctx.db.get(approvalId))).resolves.toMatchObject({
+      approvedBy: adminId,
+      status: 'approved',
+    })
+  })
+
+  it('rejects the same JWT after its canonical session is revoked', async () => {
+    const { test, approvalId } = await setup()
+    await test.mutation(components.betterAuth.adapter.deleteOne, {
+      model: 'session',
+      where: [{ field: 'id', value: authSession.id }],
+    })
+
+    await expect(
+      test.withIdentity(identity).mutation(approveProjectDelete, { approvalId }),
+    ).rejects.toMatchObject({ data: 'Unauthenticated' })
+    await expect(test.run((ctx) => ctx.db.get(approvalId))).resolves.toMatchObject({
+      status: 'pending',
+    })
+  })
+})


### PR DESCRIPTION
## Result

A still-valid Convex session JWT could approve a destructive starter operation after its Better Auth session was deleted. The approval mutation now resolves the user through the canonical auth component, which rechecks the persisted session before evaluating the live organization role.

## Verification

- [x] `pnpm exec vitest run --project=mcp test/mcp/destructive-approval-session.test.ts`
- [x] `pnpm exec tsc -p test/mcp/tsconfig.json`
- [x] The regression proves the same JWT is rejected after its canonical session row is deleted.
- [ ] `pnpm verify` was not repeated for this isolated layer; the complete three-PR stack passed `pnpm check` and the focused security gates listed in #127.

## Documentation and compatibility

- [x] No public API or migration changes.
- [x] Added a test for the changed authentication boundary.
- [x] Kept application authorization in Convex and the PR focused on one concern.
- [x] No credentials, tokens, private data, or generated artifacts are included.

## Release note

The unreleased package-family note is included in the top stack PR, #127.

## Risk

The main risk is rejecting a valid administrator because identity projection and auth state diverge. The test covers both a live session and the same signed identity after canonical session deletion. Implemented and reviewed with Codex (GPT-5); the regression uses `convex-test` with the packaged auth component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project deletion approvals now use the authenticated user’s current session, improving authorization consistency.
  - Revoked sessions can no longer approve pending destructive actions.

- **Tests**
  - Added coverage verifying that active administrator sessions can approve project deletion.
  - Added coverage confirming revoked sessions are rejected and approvals remain pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->