### PR TITLE
fix(cli): prevent init from provisioning production

### DIFF
--- a/src/runtime/cli/convex.ts
+++ b/src/runtime/cli/convex.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { realpathSync } from 'node:fs'
 import { stat, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -71,6 +72,12 @@ const DEPLOYMENT_KEY = /^(?:dev|prod):[^:|\s]+\|\S+$/u
 const DEPLOYMENT_NAME = /^(?:custom|dev|local|preview|prod):[a-z0-9_-]+$/u
 
 type ConvexAuthorityKind = 'deployment-key' | 'deployment-name' | 'self-hosted'
+
+export interface ConvexAuthoritySnapshot {
+  digest: string
+  development: boolean
+  label: string
+}
 
 function hasValue(environment: Readonly<Record<string, string>>, name: string): boolean {
   return typeof environment[name] === 'string' && environment[name]!.length > 0
@@ -221,6 +228,34 @@ async function readAuthorityFile(cwd: string): Promise<Record<string, string>> {
   }
 }
 
+function snapshotAuthority(environment: Readonly<Record<string, string>>): ConvexAuthoritySnapshot {
+  const kind = assertConvexAuthoritySelection(environment)
+  const selector =
+    TOKEN_SELECTORS.map((name) => environment[name]).find(Boolean) ??
+    environment.CONVEX_DEPLOYMENT ??
+    'self-hosted'
+  const publicSelector = selector.includes('|')
+    ? selector.slice(0, selector.indexOf('|'))
+    : selector
+  const development =
+    (kind === 'deployment-key' && publicSelector.startsWith('dev:')) ||
+    (kind === 'deployment-name' && /^(?:anonymous:anonymous-|dev:|local:)/u.test(publicSelector))
+  const canonicalAuthority = Object.entries(environment)
+    .filter(([name]) => ALLOWED_CONVEX_FILE_NAMES.has(name))
+    .sort(([left], [right]) => left.localeCompare(right))
+  return {
+    digest: createHash('sha256').update(JSON.stringify(canonicalAuthority)).digest('hex'),
+    development,
+    label: kind === 'self-hosted' ? 'self-hosted deployment' : publicSelector,
+  }
+}
+
+export async function inspectConvexAuthority(
+  cwd: string = process.cwd(),
+): Promise<ConvexAuthoritySnapshot> {
+  return snapshotAuthority(await readAuthorityFile(resolve(cwd)))
+}
+
 function usage(): string {
   return [
     'Run the pinned Convex CLI with one explicit deployment authority.',
@@ -240,6 +275,8 @@ export async function runConvexCommand(
   arguments_: readonly string[],
   options: {
     cwd?: string
+    developmentOnly?: boolean
+    expectedAuthorityDigest?: string
     inheritedEnvironment?: NodeJS.ProcessEnv
     input?: string
     onStdout?: (output: string) => void
@@ -284,6 +321,16 @@ export async function runConvexCommand(
     assertFileBoundArguments(commandArguments)
     const authorityFile = await readAuthorityFile(cwd)
     const authorityKind = assertConvexAuthoritySelection(authorityFile)
+    const authority = snapshotAuthority(authorityFile)
+    if (options.developmentOnly && !authority.development) {
+      throw new Error('This command requires development, local, or anonymous authority.')
+    }
+    if (
+      options.expectedAuthorityDigest !== undefined &&
+      authority.digest !== options.expectedAuthorityDigest
+    ) {
+      throw new Error('The Convex authority file changed after the operation was confirmed.')
+    }
     const deploymentKey = TOKEN_SELECTORS.map((name) => authorityFile[name]).find(Boolean)
     if (command === 'deploy' && authorityKind === 'deployment-name') {
       throw new Error('Deploy requires a deployment-scoped key or self-hosted authority.')

--- a/src/runtime/cli/init.ts
+++ b/src/runtime/cli/init.ts
@@ -4,11 +4,12 @@ import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 
 import { runAuthSchemaCommand } from './auth-schema'
-import { runConvexCommand } from './convex'
+import { inspectConvexAuthority, runConvexCommand } from './convex'
 
 export interface InitDependencies {
   confirm(message: string): Promise<boolean>
   prompt(message: string, defaultValue: string): Promise<string>
+  readDevelopmentAuthorityLabel(): Promise<string>
   runConvex(args: readonly string[], input?: string): Promise<number>
   readEnvironmentNames(): Promise<ReadonlySet<string>>
   generateSchema(args: readonly string[]): Promise<number>
@@ -109,7 +110,29 @@ async function readOptional(path: string): Promise<string | undefined> {
   }
 }
 
-function defaultDependencies(): InitDependencies {
+function defaultDependencies(root: string): InitDependencies {
+  let authorityPromise: ReturnType<typeof inspectConvexAuthority> | undefined
+  const developmentAuthority = async () => {
+    authorityPromise ??= inspectConvexAuthority(root)
+    const authority = await authorityPromise
+    if (!authority.development) {
+      throw new Error('better-convex init refuses production or unclassified authority')
+    }
+    return authority
+  }
+  const runDevelopmentConvex = async (
+    args: readonly string[],
+    options: { input?: string; onStdout?: (output: string) => void } = {},
+  ) => {
+    const authority = await developmentAuthority()
+    return await runConvexCommand(args, {
+      ...options,
+      cwd: root,
+      developmentOnly: true,
+      expectedAuthorityDigest: authority.digest,
+      quiet: true,
+    })
+  }
   async function question(message: string): Promise<string> {
     const terminal = createInterface({ input: process.stdin, output: process.stdout })
     try {
@@ -127,11 +150,13 @@ function defaultDependencies(): InitDependencies {
       const answer = (await question(`${message} [${defaultValue}] `)).trim()
       return answer || defaultValue
     },
-    runConvex: async (args, input) => await runConvexCommand(args, { input, quiet: true }),
+    async readDevelopmentAuthorityLabel() {
+      return (await developmentAuthority()).label
+    },
+    runConvex: async (args, input) => await runDevelopmentConvex(args, { input }),
     async readEnvironmentNames() {
       let output = ''
-      const status = await runConvexCommand(['env', 'list', '--names-only'], {
-        quiet: true,
+      const status = await runDevelopmentConvex(['env', 'list', '--names-only'], {
         onStdout: (value) => {
           output += value
         },
@@ -253,9 +278,9 @@ export async function runInitCommand(
     console.log('Usage: better-convex init [--typed-client]')
     return 0
   }
-  const defaults = defaultDependencies()
-  const dependencies: InitDependencies = { ...defaults, ...overrides }
   const root = process.cwd()
+  const defaults = defaultDependencies(root)
+  const dependencies: InitDependencies = { ...defaults, ...overrides }
   const schemaPath = join(root, 'convex/betterAuth/schema.ts')
   const metadataPath = join(root, 'convex/betterAuth/schemaMetadata.ts')
   const [schema, metadata] = await Promise.all([
@@ -291,7 +316,12 @@ export async function runInitCommand(
       'Generated auth schema conflicts with the reviewed plugin profile. Run better-convex auth schema and review the diff manually.',
     )
   }
-  if (!(await dependencies.confirm('Provision development secrets and the first signing key?'))) {
+  const authorityLabel = await dependencies.readDevelopmentAuthorityLabel()
+  if (
+    !(await dependencies.confirm(
+      `Provision development secrets and the first signing key in ${authorityLabel}?`,
+    ))
+  ) {
     return 0
   }
   await provisionDevelopment(dependencies)

--- a/test/unit/convex-command-authority.test.ts
+++ b/test/unit/convex-command-authority.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   assertConvexAuthoritySelection,
   buildConvexCommandEnvironment,
+  inspectConvexAuthority,
   runConvexCommand,
 } from '../../src/runtime/cli/convex'
 
@@ -245,6 +246,50 @@ describe('checked Convex CLI deployment authority', () => {
       rmSync(keyDirectory, { force: true, recursive: true })
       rmSync(prodDirectory, { force: true, recursive: true })
       rmSync(prodKeyDirectory, { force: true, recursive: true })
+    }
+  })
+
+  it('pins development-only commands to one confirmed authority snapshot', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'bcn-convex-development-authority-'))
+    const cliDirectory = join(cwd, 'node_modules/convex/bin')
+    mkdirSync(cliDirectory, { recursive: true })
+    writeFileSync(join(cwd, '.env.local'), 'CONVEX_DEPLOYMENT=dev:confirmed\n', { mode: 0o600 })
+    writeFileSync(join(cliDirectory, 'main.js'), 'process.exitCode = 0\n')
+
+    try {
+      const authority = await inspectConvexAuthority(cwd)
+      expect(authority).toMatchObject({ development: true, label: 'dev:confirmed' })
+      await expect(
+        runConvexCommand(['env', 'list', '--names-only'], {
+          cwd,
+          developmentOnly: true,
+          expectedAuthorityDigest: authority.digest,
+          quiet: true,
+        }),
+      ).resolves.toBe(0)
+
+      writeFileSync(join(cwd, '.env.local'), 'CONVEX_DEPLOYMENT=dev:changed\n', { mode: 0o600 })
+      await expect(
+        runConvexCommand(['env', 'list', '--names-only'], {
+          cwd,
+          developmentOnly: true,
+          expectedAuthorityDigest: authority.digest,
+          quiet: true,
+        }),
+      ).rejects.toThrow('authority file changed')
+
+      writeFileSync(join(cwd, '.env.local'), 'CONVEX_DEPLOY_KEY=prod:production|secret\n', {
+        mode: 0o600,
+      })
+      await expect(
+        runConvexCommand(['run', 'auth:ensureSigningKey', '{}'], {
+          cwd,
+          developmentOnly: true,
+          quiet: true,
+        }),
+      ).rejects.toThrow('requires development, local, or anonymous authority')
+    } finally {
+      rmSync(cwd, { force: true, recursive: true })
     }
   })
 

--- a/test/unit/init-command.test.ts
+++ b/test/unit/init-command.test.ts
@@ -28,6 +28,9 @@ function createHarness(confirmations: boolean[] = [true, true, true]): Harness {
     async prompt() {
       return 'http://localhost:4173'
     },
+    async readDevelopmentAuthorityLabel() {
+      return 'dev:fixture'
+    },
     async runConvex(args, input) {
       convexCalls.push({ args, input })
       if (args[0] === 'env' && args[1] === 'set') {
@@ -93,6 +96,7 @@ describe.sequential('better-convex init', () => {
     expect(JSON.stringify(harness.convexCalls.map(({ args }) => args))).not.toContain(
       'SENTINEL_SECRET_DO_NOT_LOG',
     )
+    expect(harness.confirmations.at(-1)).toContain('dev:fixture')
   })
 
   it('writes nothing when the file plan is cancelled', async () => {
@@ -204,5 +208,31 @@ describe.sequential('better-convex init', () => {
     await expect(runInitCommand(['--prod'], createHarness().dependencies)).rejects.toThrow(
       'refuses production',
     )
+  })
+
+  it('refuses production authority before starting a provisioning command', async () => {
+    await mkdir(join(root, 'node_modules/convex/bin'), { recursive: true })
+    await writeFile(
+      join(root, '.env.local'),
+      'CONVEX_DEPLOY_KEY=prod:fixture-production|not-a-real-credential\n',
+      { mode: 0o600 },
+    )
+    await writeFile(
+      join(root, 'node_modules/convex/bin/main.js'),
+      "require('node:fs').writeFileSync('production-command-started', 'unsafe')\n",
+    )
+
+    await expect(
+      runInitCommand([], {
+        confirm: async () => true,
+        generateSchema: async () => 0,
+        log: () => undefined,
+        prompt: async (_message, defaultValue) => defaultValue,
+        randomSecret: () => 'fixture-generated-secret-never-real',
+      }),
+    ).rejects.toThrow('refuses production or unclassified authority')
+    await expect(readFile(join(root, 'production-command-started'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
   })
 })


### PR DESCRIPTION
## Result

The development initializer could confirm one deployment and later run `env` or `run` against changed or production credentials from `.env.local`. It now snapshots one development-only Convex authority, binds every provisioning command to its digest, and rejects production or changed authority before spawning the Convex CLI.

## Verification

- [x] `pnpm exec vitest run --project=unit test/unit/convex-command-authority.test.ts test/unit/init-command.test.ts`
- [x] Tests cover an accepted development authority, a changed development key, and a production key rejected before subprocess creation.
- [ ] `pnpm verify` was not repeated for this isolated layer; the complete three-PR stack passed `pnpm check` and the focused security gates listed in #127.

## Documentation and compatibility

- [x] No public runtime API or data migration changes.
- [x] Added tests for the changed deployment-authority invariant.
- [x] Kept server-only authority handling outside browser bundles and the PR focused on one concern.
- [x] The authority label excludes secret material; no credentials or tokens are logged.

## Release note

The unreleased package-family note is included in the top stack PR, #127.

## Risk

The main risk is blocking a legitimate local initializer. Tests exercise both supported development key/name forms and prove the command is stopped only when the authority is not development or changes after confirmation. Implemented and reviewed with Codex (GPT-5); subprocess behavior is covered with the existing CLI harness.
