### PR TITLE
test(auth): expose contention effort without private data

### DIFF
--- a/scripts/run-auth-concurrency.mjs
+++ b/scripts/run-auth-concurrency.mjs
@@ -159,13 +159,25 @@ async function runWorker() {
     return client.mutation(authConcurrencyFunctions[functionName], args)
   }
   const invoke = async (index) => {
+    const started = performance.now()
     for (let attempt = 0; ; attempt += 1) {
       try {
-        return { ok: true, value: await invokeOnce(index) }
+        const value = await invokeOnce(index)
+        return {
+          ok: true,
+          value,
+          attempts: attempt + 1,
+          elapsedMs: Math.round(performance.now() - started),
+        }
       } catch (error) {
         const failure = safeAuthConcurrencyFailure(error)
         if (!shouldRetryAuthContention(operation, failure, attempt)) {
-          return { ok: false, error: failure }
+          return {
+            ok: false,
+            error: failure,
+            attempts: attempt + 1,
+            elapsedMs: Math.round(performance.now() - started),
+          }
         }
         // A final Convex OCC contention error means the mutation did not commit.
         // Never retry ambiguous transport/action failures: an increment must
@@ -300,16 +312,25 @@ function assertPristineRaceRow(row, expected, message) {
   )
 }
 
-function failureSummary(results) {
+export function failureSummary(results) {
   const counts = new Map()
+  const attempts = new Map()
+  let maxElapsedMs = 0
   for (const result of results) {
+    attempts.set(result.attempts, (attempts.get(result.attempts) ?? 0) + 1)
+    maxElapsedMs = Math.max(maxElapsedMs, result.elapsedMs)
     if (result.ok) continue
     counts.set(result.error, (counts.get(result.error) ?? 0) + 1)
   }
-  return [...counts.entries()]
+  const failures = [...counts.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, count]) => `${name}=${count}`)
     .join(', ')
+  const histogram = [...attempts.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([attempt, count]) => `${attempt}:${count}`)
+    .join(',')
+  return `${failures}; requestAttempts={${histogram}}; maxElapsedMs=${maxElapsedMs}`
 }
 
 function signClientIp(clientIp) {

--- a/test/security/workforce-provider-hooks.test.ts
+++ b/test/security/workforce-provider-hooks.test.ts
@@ -597,10 +597,17 @@ describe('owned workforce provider hooks', () => {
     const h = await fixture()
     const user = await h.enabled()
     await h.proof(user.sessionId, 'password-totp')
-    expect((await h.post('/two-factor/verify-totp', { code: '000000' }, user.jar)).status).toBe(403)
-    expect(
-      (await h.post('/two-factor/verify-backup-code', { code: 'synthetic' }, user.jar)).status,
-    ).toBe(403)
+    for (const [path, body] of [
+      ['/two-factor/verify-totp', { code: '000000' }],
+      ['/two-factor/verify-backup-code', { code: 'synthetic' }],
+    ] as const) {
+      const result = await h.post(path, body, user.jar).then(
+        (response) => ({ response }),
+        (error: unknown) => ({ error }),
+      )
+      if ('response' in result) expect(result.response.status).toBe(403)
+      else expect(result.error).toMatchObject({ status: 'FORBIDDEN' })
+    }
     expect(h.relayed).toHaveLength(0)
   })
 

--- a/test/unit/oauth-transport-quota.test.ts
+++ b/test/unit/oauth-transport-quota.test.ts
@@ -7,6 +7,7 @@ import { parse } from 'yaml'
 import {
   AUTH_CONTENTION_MAX_RETRIES,
   authContentionRetryDelayMs,
+  failureSummary,
   safeAuthConcurrencyFailure,
   shouldRetryAuthContention,
 } from '../../scripts/run-auth-concurrency.mjs'
@@ -221,6 +222,22 @@ describe('real OAuth transport quota evidence', () => {
     expect(() => authContentionRetryDelayMs(-1, 0, 0)).toThrow(
       'AUTH_CONTENTION_RETRY_INPUT_INVALID',
     )
+  })
+
+  it('reports bounded retry effort without successful values or raw errors', () => {
+    const summary = failureSummary([
+      { ok: true, value: { token: 'private-sentinel' }, attempts: 1, elapsedMs: 10 },
+      { ok: true, value: 2, attempts: 2, elapsedMs: 40 },
+      {
+        ok: false,
+        error: safeAuthConcurrencyFailure(new Error('OCC error private-error-sentinel')),
+        attempts: 6,
+        elapsedMs: 1200,
+      },
+      { ok: false, error: 'CONVEX_CONTENTION', attempts: 6, elapsedMs: 1100 },
+    ])
+    expect(summary).toBe('CONVEX_CONTENTION=2; requestAttempts={1:1,2:1,6:2}; maxElapsedMs=1200')
+    expect(summary).not.toContain('sentinel')
   })
 
   it('preserves exact safe uniqueness evidence from the real-backend races', () => {


### PR DESCRIPTION
The same source passed the auth load test once and later exhausted contention retries for two requests. Add bounded attempt counts and elapsed-time summaries so the next Linux run can distinguish retry exhaustion from a lost-update defect.

Keep the existing workload, retry policy, maximum attempts, invariants, and failure categories unchanged. The privacy test verifies that diagnostics omit successful response values and raw errors.

The first protected rerun exposed an unrelated full-suite assertion that treated Better Auth's typed `FORBIDDEN` rejection differently from the equivalent HTTP 403 response. The security invariant is transport-neutral now: both operations must be denied and neither may relay a full-login session.

This is layer 2 of 5. The focused transport/quota tests pass. The forbidden-route file passes all 47 tests, and its changed assertion passes repeatedly in isolation. The reviewed combined stack also passed `pnpm verify` locally (2,753 tests). The Linux nightly auth-load profile remains required before deciding whether retry behavior needs any change; no retry change is proposed here.

Implemented and independently reviewed with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication concurrency reporting with clearer attempt counts, elapsed-time metrics, and concise failure summaries.
  - Ensured two-factor verification using either authenticator codes or backup codes does not incorrectly start a new full login when a session already exists.

- **Tests**
  - Added coverage for mixed authentication outcomes and both supported two-factor verification paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->